### PR TITLE
✨ Feat: 엔티티 생성 Part2 (Group Entity 수정)

### DIFF
--- a/src/main/java/org/dongguk/jjoin/domain/Group.java
+++ b/src/main/java/org/dongguk/jjoin/domain/Group.java
@@ -1,0 +1,52 @@
+package org.dongguk.jjoin.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.dongguk.jjoin.domain.type.DependentType;
+
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@Table(name = "group")
+public class Group {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "introduction")
+    private String introduction;
+
+    @Column(name = "leader_id", nullable = false)
+    private Long leaderId;
+
+    @Column(name = "dependent", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private DependentType dependent;
+
+    @Column(name = "created_date")
+    private Timestamp createdDate;
+
+    @Column(name = "group_profile")
+    private Long groupProfile;
+
+    @Column(name = "background_image")
+    private Long backgroundImage;
+
+    //--------------------------------------------------------
+    @OneToMany(mappedBy = "Group_tag", fetch = FetchType.LAZY)
+    List<Group_tag> groupTags = new ArrayList<>();
+
+    @OneToMany(mappedBy = "Group_member", fetch = FetchType.LAZY)
+    List<Group_member> group_members = new ArrayList<>();
+}

--- a/src/main/java/org/dongguk/jjoin/domain/Group.java
+++ b/src/main/java/org/dongguk/jjoin/domain/Group.java
@@ -40,13 +40,16 @@ public class Group {
     @Column(name = "created_date")
     private Timestamp createdDate;
 
-    @Column(name = "group_profile")
-    private Long groupProfile;
+    @OneToOne
+    @JoinColumn(name = "group_profile")
+    private Image groupProfile;
 
-    @Column(name = "background_image")
-    private Long backgroundImage;
+    @OneToOne
+    @JoinColumn(name = "background_image")
+    private Image backgroundImage;
 
     //--------------------------------------------------------
+
     @OneToMany(mappedBy = "Group_tag", fetch = FetchType.LAZY)
     List<Group_tag> groupTags = new ArrayList<>();
 

--- a/src/main/java/org/dongguk/jjoin/domain/Group.java
+++ b/src/main/java/org/dongguk/jjoin/domain/Group.java
@@ -29,8 +29,9 @@ public class Group {
     @Column(name = "introduction")
     private String introduction;
 
-    @Column(name = "leader_id", nullable = false)
-    private Long leaderId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "leader_id", nullable = false)
+    private User leader;
 
     @Column(name = "dependent", nullable = false)
     @Enumerated(EnumType.STRING)
@@ -53,10 +54,10 @@ public class Group {
     List<Group_member> group_members = new ArrayList<>();
 
     @Builder
-    public Group(String name, String introduction, Long leaderId, DependentType dependent, Long groupProfile, Long backgroundImage) {
+    public Group(String name, String introduction, User leader, DependentType dependent, Long groupProfile, Long backgroundImage) {
         this.name = name;
         this.introduction = introduction;
-        this.leaderId = leaderId;
+        this.leader = leader;
         this.dependent = dependent;
         this.createdDate = Timestamp.valueOf(LocalDateTime.now());;
         this.groupProfile = groupProfile;

--- a/src/main/java/org/dongguk/jjoin/domain/Group.java
+++ b/src/main/java/org/dongguk/jjoin/domain/Group.java
@@ -1,12 +1,14 @@
 package org.dongguk.jjoin.domain;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.dongguk.jjoin.domain.type.DependentType;
 
 import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -49,4 +51,15 @@ public class Group {
 
     @OneToMany(mappedBy = "Group_member", fetch = FetchType.LAZY)
     List<Group_member> group_members = new ArrayList<>();
+
+    @Builder
+    public Group(String name, String introduction, Long leaderId, DependentType dependent, Long groupProfile, Long backgroundImage) {
+        this.name = name;
+        this.introduction = introduction;
+        this.leaderId = leaderId;
+        this.dependent = dependent;
+        this.createdDate = Timestamp.valueOf(LocalDateTime.now());;
+        this.groupProfile = groupProfile;
+        this.backgroundImage = backgroundImage;
+    }
 }

--- a/src/main/java/org/dongguk/jjoin/domain/Group_application.java
+++ b/src/main/java/org/dongguk/jjoin/domain/Group_application.java
@@ -1,11 +1,13 @@
 package org.dongguk.jjoin.domain;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.sql.Timestamp;
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -28,4 +30,11 @@ public class Group_application {
 
     @Column(name = "request_date", nullable = false)
     private Timestamp requestDate;
+
+    @Builder
+    public Group_application(User user, Group group) {
+        this.user = user;
+        this.group = group;
+        requestDate = Timestamp.valueOf(LocalDateTime.now());
+    }
 }

--- a/src/main/java/org/dongguk/jjoin/domain/Group_application.java
+++ b/src/main/java/org/dongguk/jjoin/domain/Group_application.java
@@ -1,0 +1,31 @@
+package org.dongguk.jjoin.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.sql.Timestamp;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@Table(name = "group_application")
+public class Group_application {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "group_id", nullable = false)
+    private Group group;
+
+    @Column(name = "request_date", nullable = false)
+    private Timestamp requestDate;
+}

--- a/src/main/java/org/dongguk/jjoin/domain/Group_member.java
+++ b/src/main/java/org/dongguk/jjoin/domain/Group_member.java
@@ -1,12 +1,14 @@
 package org.dongguk.jjoin.domain;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.dongguk.jjoin.domain.type.RankType;
 
 import java.sql.Timestamp;
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -33,4 +35,12 @@ public class Group_member {
 
     @Column(name = "register_date", nullable = false)
     private Timestamp registerDate;
+
+    @Builder
+    public Group_member(User user, Group group, RankType rankType) {
+        this.user = user;
+        this.group = group;
+        this.rankType = rankType;
+        registerDate = Timestamp.valueOf(LocalDateTime.now());
+    }
 }

--- a/src/main/java/org/dongguk/jjoin/domain/Group_member.java
+++ b/src/main/java/org/dongguk/jjoin/domain/Group_member.java
@@ -1,0 +1,36 @@
+package org.dongguk.jjoin.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.dongguk.jjoin.domain.type.RankType;
+
+import java.sql.Timestamp;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@Table(name = "group_member")
+public class Group_member {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "group_id", nullable = false)
+    private Group group;
+
+    @Column(name = "rank", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private RankType rankType;
+
+    @Column(name = "register_date", nullable = false)
+    private Timestamp registerDate;
+}

--- a/src/main/java/org/dongguk/jjoin/domain/Group_tag.java
+++ b/src/main/java/org/dongguk/jjoin/domain/Group_tag.java
@@ -1,0 +1,26 @@
+package org.dongguk.jjoin.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@Table(name = "group_tag")
+public class Group_tag {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "group_id", nullable = false)
+    private Group group;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "tag_id", nullable = false)
+    private Tag tag;
+}

--- a/src/main/java/org/dongguk/jjoin/domain/Group_tag.java
+++ b/src/main/java/org/dongguk/jjoin/domain/Group_tag.java
@@ -1,6 +1,7 @@
 package org.dongguk.jjoin.domain;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -23,4 +24,10 @@ public class Group_tag {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "tag_id", nullable = false)
     private Tag tag;
+
+    @Builder
+    public Group_tag(Group group, Tag tag) {
+        this.group = group;
+        this.tag = tag;
+    }
 }

--- a/src/main/java/org/dongguk/jjoin/domain/Recruited_period.java
+++ b/src/main/java/org/dongguk/jjoin/domain/Recruited_period.java
@@ -1,0 +1,33 @@
+package org.dongguk.jjoin.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.sql.Timestamp;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@Table(name = "recruited_period")
+public class Recruited_period {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @OneToOne
+    @Column(name = "group_id", nullable = false)
+    private Group group;
+
+    @Column(name = "start_date", nullable = false)
+    private Timestamp startDate;
+
+    @Column(name = "end_date", nullable = false)
+    private Timestamp endDate;
+
+    @Column(name = "is_finished", nullable = false)
+    private Boolean isFinished;
+}

--- a/src/main/java/org/dongguk/jjoin/domain/Recruited_period.java
+++ b/src/main/java/org/dongguk/jjoin/domain/Recruited_period.java
@@ -1,6 +1,7 @@
 package org.dongguk.jjoin.domain;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -30,4 +31,12 @@ public class Recruited_period {
 
     @Column(name = "is_finished", nullable = false)
     private Boolean isFinished;
+
+    @Builder
+    public Recruited_period(Group group, Timestamp startDate, Timestamp endDate) {
+        this.group = group;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        isFinished = false;
+    }
 }

--- a/src/main/java/org/dongguk/jjoin/domain/Recruited_period.java
+++ b/src/main/java/org/dongguk/jjoin/domain/Recruited_period.java
@@ -20,7 +20,7 @@ public class Recruited_period {
     private Long id;
 
     @OneToOne
-    @Column(name = "group_id", nullable = false)
+    @JoinColumn(name = "group_id", nullable = false)
     private Group group;
 
     @Column(name = "start_date", nullable = false)

--- a/src/main/java/org/dongguk/jjoin/domain/Tag.java
+++ b/src/main/java/org/dongguk/jjoin/domain/Tag.java
@@ -1,0 +1,27 @@
+package org.dongguk.jjoin.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@Table(name="tag")
+public class Tag {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @OneToMany(mappedBy = "Group_tag", fetch = FetchType.LAZY)
+    List<Group_tag> groupTags = new ArrayList<>();
+}

--- a/src/main/java/org/dongguk/jjoin/domain/Tag.java
+++ b/src/main/java/org/dongguk/jjoin/domain/Tag.java
@@ -1,6 +1,7 @@
 package org.dongguk.jjoin.domain;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -24,4 +25,9 @@ public class Tag {
 
     @OneToMany(mappedBy = "Group_tag", fetch = FetchType.LAZY)
     List<Group_tag> groupTags = new ArrayList<>();
+
+    @Builder
+    public Tag(String name) {
+        this.name = name;
+    }
 }

--- a/src/main/java/org/dongguk/jjoin/domain/User.java
+++ b/src/main/java/org/dongguk/jjoin/domain/User.java
@@ -31,7 +31,6 @@ public class User {
     @Column(name ="serial_id")
     private String serialId;
 
-
     @Column(name = "password", nullable = false)
     private String password;
 
@@ -50,14 +49,18 @@ public class User {
 
     @Column(name = "created_date")
     private Timestamp createdDate;
+
     @Column(name = "is_login", nullable = false)
     private Boolean isLogin;
+
     @Column(name = "refresh_token")
     private String refreshToken;
+
     @Column(name = "device_token")
     private String deviceToken;
 
     //--------------------------------------------------------
+
     @OneToMany(mappedBy = "Group_member", fetch = FetchType.LAZY)
     List<Group_member> group_members = new ArrayList<>();
 

--- a/src/main/java/org/dongguk/jjoin/domain/User.java
+++ b/src/main/java/org/dongguk/jjoin/domain/User.java
@@ -1,0 +1,57 @@
+package org.dongguk.jjoin.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.dongguk.jjoin.domain.type.EUserRole;
+import org.dongguk.jjoin.domain.type.ELoginProvider;
+
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@Table(name = "user")
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "provider", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ELoginProvider provider;
+
+    @Column(name = "password", nullable = false)
+    private String password;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "introduction")
+    private String introduction;
+
+    @Column(name = "email", nullable = false)
+    private String email;
+
+    @Column(name = "role", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private EUserRole role;
+
+    @Column(name = "created_date")
+    private Timestamp createdDate;
+    @Column(name = "is_login", nullable = false)
+    private Boolean isLogin;
+    @Column(name = "refresh_token")
+    private String refreshToken;
+    @Column(name = "device_token")
+    private String deviceToken;
+
+    //--------------------------------------------------------
+    @OneToMany(mappedBy = "Group_member", fetch = FetchType.LAZY)
+    List<Group_member> group_members = new ArrayList<>();
+}

--- a/src/main/java/org/dongguk/jjoin/domain/User.java
+++ b/src/main/java/org/dongguk/jjoin/domain/User.java
@@ -1,6 +1,7 @@
 package org.dongguk.jjoin.domain;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -8,6 +9,7 @@ import org.dongguk.jjoin.domain.type.EUserRole;
 import org.dongguk.jjoin.domain.type.ELoginProvider;
 
 import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -25,6 +27,10 @@ public class User {
     @Column(name = "provider", nullable = false)
     @Enumerated(EnumType.STRING)
     private ELoginProvider provider;
+
+    @Column(name ="serial_id")
+    private String serialId;
+
 
     @Column(name = "password", nullable = false)
     private String password;
@@ -54,4 +60,20 @@ public class User {
     //--------------------------------------------------------
     @OneToMany(mappedBy = "Group_member", fetch = FetchType.LAZY)
     List<Group_member> group_members = new ArrayList<>();
+
+    @Builder
+    public User(ELoginProvider provider, String serialId, String password, String name,
+                String introduction, String email, EUserRole role) {
+        this.provider = provider;
+        this.serialId = serialId;
+        this.password = password;
+        this.name = name;
+        this.introduction = introduction;
+        this.email = email;
+        this.role = role;
+        this.createdDate = Timestamp.valueOf(LocalDateTime.now());
+        this.isLogin = true;
+        this.refreshToken = null;
+        this.deviceToken = null;
+    }
 }

--- a/src/main/java/org/dongguk/jjoin/domain/type/DependentType.java
+++ b/src/main/java/org/dongguk/jjoin/domain/type/DependentType.java
@@ -1,0 +1,5 @@
+package org.dongguk.jjoin.domain.type;
+
+public enum DependentType {
+    MAJOR, CENTER
+}

--- a/src/main/java/org/dongguk/jjoin/domain/type/ELoginProvider.java
+++ b/src/main/java/org/dongguk/jjoin/domain/type/ELoginProvider.java
@@ -1,0 +1,5 @@
+package org.dongguk.jjoin.domain.type;
+
+public enum ELoginProvider {
+    KAKAO, GOOGLE, APPLE, DEFAULT
+}

--- a/src/main/java/org/dongguk/jjoin/domain/type/EUserRole.java
+++ b/src/main/java/org/dongguk/jjoin/domain/type/EUserRole.java
@@ -1,0 +1,5 @@
+package org.dongguk.jjoin.domain.type;
+
+public enum EUserRole {
+    USER, ADMIN
+}

--- a/src/main/java/org/dongguk/jjoin/domain/type/RankType.java
+++ b/src/main/java/org/dongguk/jjoin/domain/type/RankType.java
@@ -1,0 +1,5 @@
+package org.dongguk.jjoin.domain.type;
+
+public enum RankType {
+    LEADER, MANAGER, MEMBER
+}


### PR DESCRIPTION
Entity Part2를 추가하고
Group Entity에서 leaderId값 대신 User 테이블을 참조하여, leaderId에 해당하는 User 객체를 저장하도록 수정했습니다.