### PR TITLE
✨ Feat: 동아리 게시글 구현 (앱)

### DIFF
--- a/src/main/java/org/dongguk/jjoin/controller/ClubController.java
+++ b/src/main/java/org/dongguk/jjoin/controller/ClubController.java
@@ -1,6 +1,7 @@
 package org.dongguk.jjoin.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.dongguk.jjoin.dto.response.NoticeDto;
 import org.dongguk.jjoin.dto.response.NoticeListDtoByApp;
 import org.dongguk.jjoin.service.ClubService;
 import org.springframework.web.bind.annotation.*;
@@ -17,5 +18,11 @@ public class ClubController {
     @GetMapping("/{clubId}/notices")
     public List<NoticeListDtoByApp> showNoticeList(@PathVariable Long clubId, @RequestParam("page") Integer page, @RequestParam("size") Integer size){
         return clubService.showNoticeList(clubId, page, size);
+    }
+
+    // 동아리 게시글 상세정보를 보여주는 API
+    @GetMapping("/{clubId}/notices/{noticeId}")
+    public NoticeDto readNotice(@PathVariable Long clubId, @PathVariable Long noticeId){
+        return clubService.readNotice(clubId, noticeId);
     }
 }

--- a/src/main/java/org/dongguk/jjoin/controller/ClubController.java
+++ b/src/main/java/org/dongguk/jjoin/controller/ClubController.java
@@ -1,0 +1,21 @@
+package org.dongguk.jjoin.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.dongguk.jjoin.dto.response.NoticeListDtoByApp;
+import org.dongguk.jjoin.service.ClubService;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/clubs")
+public class ClubController {
+    private final ClubService clubService;
+
+    // 동아리 게시글(공지, 홍보) 목록을 보여주는 API
+    @GetMapping("/{clubId}/notices")
+    public List<NoticeListDtoByApp> showNoticeList(@PathVariable Long clubId, @RequestParam("page") Integer page, @RequestParam("size") Integer size){
+        return clubService.showNoticeList(clubId, page, size);
+    }
+}

--- a/src/main/java/org/dongguk/jjoin/dto/response/NoticeListDtoByApp.java
+++ b/src/main/java/org/dongguk/jjoin/dto/response/NoticeListDtoByApp.java
@@ -1,0 +1,22 @@
+package org.dongguk.jjoin.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.sql.Timestamp;
+
+@Getter
+public class NoticeListDtoByApp {
+    private Long id;
+    private String title;
+    private String content;
+    private Timestamp updatedDate;
+
+    @Builder
+    public NoticeListDtoByApp(Long id, String title, String content, Timestamp updatedDate) {
+        this.id = id;
+        this.title = title;
+        this.content = content;
+        this.updatedDate = updatedDate;
+    }
+}

--- a/src/main/java/org/dongguk/jjoin/service/ClubService.java
+++ b/src/main/java/org/dongguk/jjoin/service/ClubService.java
@@ -1,0 +1,43 @@
+package org.dongguk.jjoin.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.dongguk.jjoin.domain.Club;
+import org.dongguk.jjoin.domain.Notice;
+import org.dongguk.jjoin.dto.response.NoticeListDtoByApp;
+import org.dongguk.jjoin.repository.ClubRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ClubService {
+    private final ClubRepository clubRepository;
+
+    // 동아리 게시글(공지, 홍보) 목록을 보여주는 API
+    public List<NoticeListDtoByApp> showNoticeList(Long clubId, Integer page, Integer size){
+        Club club = clubRepository.findById(clubId).orElseThrow(()-> new RuntimeException("no match clubId"));
+        List<Notice> notices = Optional.ofNullable(club.getNotices()).orElseThrow(()-> new RuntimeException("Notice Not found!"));
+        notices.removeIf(notice -> notice.isDeleted());
+        notices.sort(Comparator.comparing(Notice::getUpdatedDate).reversed());
+
+        int startIdx = page * size;
+        List<Notice> showNotices = notices.subList(startIdx, Math.min(startIdx + size, notices.size()));
+        List<NoticeListDtoByApp> noticeListDtoByApps = new ArrayList<>();
+        for (Notice n : showNotices){
+            noticeListDtoByApps.add(NoticeListDtoByApp.builder()
+                            .id(n.getId())
+                            .title(n.getTitle())
+                            .content(n.getContent())
+                            .updatedDate(n.getUpdatedDate()).build());
+        }
+        return noticeListDtoByApps;
+    }
+}

--- a/src/main/java/org/dongguk/jjoin/service/ClubService.java
+++ b/src/main/java/org/dongguk/jjoin/service/ClubService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.dongguk.jjoin.domain.Club;
 import org.dongguk.jjoin.domain.Notice;
+import org.dongguk.jjoin.dto.response.NoticeDto;
 import org.dongguk.jjoin.dto.response.NoticeListDtoByApp;
 import org.dongguk.jjoin.repository.ClubRepository;
 import org.springframework.stereotype.Service;
@@ -39,5 +40,20 @@ public class ClubService {
                             .updatedDate(n.getUpdatedDate()).build());
         }
         return noticeListDtoByApps;
+    }
+
+    // 동아리 게시글 상세정보를 보여주는 API
+    public NoticeDto readNotice(Long clubId, Long noticeId){
+        Club club = clubRepository.findById(clubId).orElseThrow(()-> new RuntimeException("no match clubId"));
+        Notice notice = club.getNotices().stream()
+                .filter(n -> n.getId().equals(noticeId)).findAny()
+                .orElseThrow(() -> new RuntimeException("No match noticeId"));
+
+        return NoticeDto.builder()
+                .id(notice.getId())
+                .title(notice.getTitle())
+                .content(notice.getContent())
+                .createdDate(notice.getCreatedDate())
+                .updatedDate(notice.getUpdatedDate()).build();
     }
 }


### PR DESCRIPTION
동아리 게시글 목록 보기를 구현했으나
해당 유저가 동아리 회원일 경우만 공지글을 확인할 수 있기에, 추후에 **로그인이 구현되면 사용자가 해당 club의 멤버가 아닐 경우 공지 게시판 접근이 불가능하게 하는 로직이 추가되어야 할 것 같습니다.**

> [FEAT] 동아리 게시글 구현 (앱) https://github.com/In-lyeog-sa-mu-so/jjoin-server/issues/22 
