### PR TITLE
🐛 Fix: showNoticeList 수정

### DIFF
--- a/src/main/java/org/dongguk/jjoin/service/ManagerService.java
+++ b/src/main/java/org/dongguk/jjoin/service/ManagerService.java
@@ -7,6 +7,7 @@ import org.dongguk.jjoin.domain.Notice;
 import org.dongguk.jjoin.dto.request.NoticeRequestDto;
 import org.dongguk.jjoin.dto.response.NoticeDto;
 import org.dongguk.jjoin.dto.response.NoticeListDto;
+import org.dongguk.jjoin.dto.response.NoticeListDtoByApp;
 import org.dongguk.jjoin.repository.ClubRepository;
 import org.dongguk.jjoin.repository.NoticeRepository;
 import org.springframework.data.domain.Page;
@@ -31,20 +32,17 @@ public class ManagerService {
     public List<NoticeListDto> showNoticeList(Long clubId, Integer page, Integer size){
         Club club = clubRepository.findById(clubId).orElseThrow(()-> new RuntimeException("no match clubId"));
         List<Notice> notices = Optional.ofNullable(club.getNotices()).orElseThrow(()-> new RuntimeException("Notice Not found!"));
+        notices.removeIf(notice -> notice.isDeleted());
         notices.sort(Comparator.comparing(Notice::getUpdatedDate).reversed());
 
-        PageRequest pageRequest = PageRequest.of(page, size);
-        Page<Notice> noticePage = new PageImpl<>(notices, pageRequest, notices.size());
+        int startIdx = page * size;
+        List<Notice> showNotices = notices.subList(startIdx, Math.min(startIdx + size, notices.size()));
         List<NoticeListDto> noticeListDtos = new ArrayList<>();
-        int startIndex = (int) (page * size);
-        int endIndex = Math.min(startIndex + size, notices.size());
-        for (int i = startIndex; i < endIndex; i++) {
-            Notice n = noticePage.getContent().get(i);
+        for (Notice n : showNotices){
             noticeListDtos.add(NoticeListDto.builder()
-                            .id(n.getId())
-                            .title(n.getTitle())
-                            .updatedDate(n.getUpdatedDate())
-                            .build());
+                    .id(n.getId())
+                    .title(n.getTitle())
+                    .updatedDate(n.getUpdatedDate()).build());
         }
         return noticeListDtos;
     }


### PR DESCRIPTION
관리자 웹페이지에서 게시글 리스트를 확인할때 삭제된 리스트도 보여져서
게시글 목록을 불러올때 삭제된 리스트를 제외하는 로직을 추가했습니다.
> [FIX] 삭제된 게시글 목록보이는 버그 https://github.com/In-lyeog-sa-mu-so/jjoin-server/issues/23