### PR TITLE
✨ Feat : 동아리 검색 API 구현

### DIFF
--- a/src/main/java/org/dongguk/jjoin/controller/SearchController.java
+++ b/src/main/java/org/dongguk/jjoin/controller/SearchController.java
@@ -1,0 +1,21 @@
+package org.dongguk.jjoin.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.dongguk.jjoin.service.SearchService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/search")
+public class SearchController {
+    private final SearchService searchService;
+    @GetMapping
+    public void searchClubs(@RequestParam String keyword, @RequestParam List<String> tags, @RequestParam Integer page, @RequestParam Integer size){
+        searchService.searchClubs(keyword, tags, page, size);
+    }
+}

--- a/src/main/java/org/dongguk/jjoin/controller/SearchController.java
+++ b/src/main/java/org/dongguk/jjoin/controller/SearchController.java
@@ -1,6 +1,7 @@
 package org.dongguk.jjoin.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.dongguk.jjoin.dto.response.SearchClubDto;
 import org.dongguk.jjoin.service.SearchService;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -15,7 +16,7 @@ import java.util.List;
 public class SearchController {
     private final SearchService searchService;
     @GetMapping
-    public void searchClubs(@RequestParam String keyword, @RequestParam List<String> tags, @RequestParam Integer page, @RequestParam Integer size){
-        searchService.searchClubs(keyword, tags, page, size);
+    public List<SearchClubDto> searchClubs(@RequestParam String keyword, @RequestParam List<String> tags, @RequestParam Integer page, @RequestParam Integer size){
+        return searchService.searchClubs(keyword, tags, page, size);
     }
 }

--- a/src/main/java/org/dongguk/jjoin/dto/response/SearchClubDto.java
+++ b/src/main/java/org/dongguk/jjoin/dto/response/SearchClubDto.java
@@ -1,0 +1,32 @@
+package org.dongguk.jjoin.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.sql.Timestamp;
+
+@Getter
+public class SearchClubDto {
+    private Long clubId;
+    private String clubName;
+    private String introduction;
+    private Long userNumber;
+    private String dependent;
+    private String profileImageUuid;
+    private boolean isFinished;
+    private Timestamp startDate;
+    private Timestamp endDate;
+
+    @Builder
+    public SearchClubDto(Long clubId, String clubName, String introduction, Long userNumber, String dependent, String profileImageUuid, boolean isFinished, Timestamp startDate, Timestamp endDate) {
+        this.clubId = clubId;
+        this.clubName = clubName;
+        this.introduction = introduction;
+        this.userNumber = userNumber;
+        this.dependent = dependent;
+        this.profileImageUuid = profileImageUuid;
+        this.isFinished = isFinished;
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+}

--- a/src/main/java/org/dongguk/jjoin/repository/ClubRepository.java
+++ b/src/main/java/org/dongguk/jjoin/repository/ClubRepository.java
@@ -13,7 +13,7 @@ public interface ClubRepository extends JpaRepository<Club, Long> {
     @Query("SELECT c FROM Club AS c JOIN ClubTag AS ct ON ct.club = c WHERE ct.tag IN :tagList")
     List<Club> findClubsByTags(List<Tag> tagList);
 
-    @Query("SELECT c FROM Club AS c JOIN ClubTag AS ct ON ct.tag IN :tagList WHERE c.name LIKE %:keyword% OR c.introduction LIKE %:keyword%")
+    @Query("SELECT c FROM Club AS c JOIN ClubTag AS ct ON ct.club = c WHERE ct.tag IN :tagList AND (c.name LIKE %:keyword% OR c.introduction LIKE %:keyword%)")
     List<Club> findClubsByTagsAndKeyword(List<Tag> tagList, String keyword);
 
     // 검색 키워드로 클럽 검색

--- a/src/main/java/org/dongguk/jjoin/repository/ClubRepository.java
+++ b/src/main/java/org/dongguk/jjoin/repository/ClubRepository.java
@@ -1,11 +1,21 @@
 package org.dongguk.jjoin.repository;
 
 import org.dongguk.jjoin.domain.Club;
+import org.dongguk.jjoin.domain.Tag;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Repository
 public interface ClubRepository extends JpaRepository<Club, Long> {
+    @Query("SELECT c FROM Club AS c JOIN ClubTag AS ct ON ct.club = c WHERE ct.tag IN :tagList")
+    List<Club> findClubsByTags(List<Tag> tagList);
+
+    @Query("SELECT c FROM Club AS c JOIN ClubTag AS ct ON ct.tag IN :tagList WHERE c.name LIKE %:keyword% OR c.introduction LIKE %:keyword%")
+    List<Club> findClubsByTagsAndKeyword(List<Tag> tagList, String keyword);
+
+    // 검색 키워드로 클럽 검색
+    List<Club> findClubsByNameContainingOrIntroductionContaining(String keyword, String keyword2);
 }

--- a/src/main/java/org/dongguk/jjoin/repository/ClubTagRepository.java
+++ b/src/main/java/org/dongguk/jjoin/repository/ClubTagRepository.java
@@ -17,6 +17,4 @@ public interface ClubTagRepository extends JpaRepository<ClubTag, Long> {
     List<ClubTag> findByTagIdNotInUserClub(@Param("tagId") Long tagId, @Param("userClubs") List<Club> userClubs);
 
     List<ClubTag> findByClub(Club club);
-
-
 }

--- a/src/main/java/org/dongguk/jjoin/repository/ClubTagRepository.java
+++ b/src/main/java/org/dongguk/jjoin/repository/ClubTagRepository.java
@@ -13,7 +13,6 @@ import java.util.Set;
 
 @Repository
 public interface ClubTagRepository extends JpaRepository<ClubTag, Long> {
-
     @Query(value = "SELECT ct FROM ClubTag AS ct WHERE ct.tag.id = :tagId AND ct.club NOT IN :userClubs")
     List<ClubTag> findByTagIdNotInUserClub(@Param("tagId") Long tagId, @Param("userClubs") List<Club> userClubs);
 

--- a/src/main/java/org/dongguk/jjoin/repository/ClubTagRepository.java
+++ b/src/main/java/org/dongguk/jjoin/repository/ClubTagRepository.java
@@ -18,4 +18,6 @@ public interface ClubTagRepository extends JpaRepository<ClubTag, Long> {
     List<ClubTag> findByTagIdNotInUserClub(@Param("tagId") Long tagId, @Param("userClubs") List<Club> userClubs);
 
     List<ClubTag> findByClub(Club club);
+
+
 }

--- a/src/main/java/org/dongguk/jjoin/repository/TagRepository.java
+++ b/src/main/java/org/dongguk/jjoin/repository/TagRepository.java
@@ -1,0 +1,14 @@
+package org.dongguk.jjoin.repository;
+
+import org.dongguk.jjoin.domain.Tag;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface TagRepository extends JpaRepository<Tag, Long> {
+    @Query("SELECT t FROM Tag t WHERE t.name IN :names")
+    List<Tag> findByNames(List<String> names);
+}

--- a/src/main/java/org/dongguk/jjoin/service/SearchService.java
+++ b/src/main/java/org/dongguk/jjoin/service/SearchService.java
@@ -1,0 +1,45 @@
+package org.dongguk.jjoin.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.dongguk.jjoin.domain.Club;
+import org.dongguk.jjoin.domain.Tag;
+import org.dongguk.jjoin.repository.ClubMemberRepository;
+import org.dongguk.jjoin.repository.ClubRepository;
+import org.dongguk.jjoin.repository.ClubTagRepository;
+import org.dongguk.jjoin.repository.TagRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+public class SearchService {
+    private final ClubRepository clubRepository;
+    private final ClubMemberRepository clubMemberRepository;
+    private final TagRepository tagRepository;
+    private final ClubTagRepository clubTagRepository;
+
+    // 동아리 검색창 (태그 검색, 키워드 검색, 태그 + 키워드 검색, 검색 옵션 X 결과 화면 제공)
+    public void searchClubs(String keyword, List<String> tags, Integer page, Integer size){
+        List<Club> clubList;
+
+        // 태그 검색
+        if (!tags.isEmpty()) {
+            List<Tag> tagList = tagRepository.findByNames(tags);
+            if (!keyword.isEmpty()) { // 태그 + 키워드 검색
+                clubList = clubRepository.findClubsByTagsAndKeyword(tagList, keyword);
+            } else {
+                clubList = clubRepository.findClubsByTags(tagList);
+            }
+        } else if (!keyword.isEmpty()) { // 키워드 검색
+            clubList = clubRepository.findClubsByNameContainingOrIntroductionContaining(keyword, keyword);
+        } else { // 검색 옵션 X
+            clubList = clubRepository.findAll();
+        }
+    }
+}


### PR DESCRIPTION
앱 화면에서 동아리 검색결과로 보여줄 화면에 필요한 API를 구현합니다.

- 일반 검색
- 키워드 검색
- 태그 검색
- 키워드+태그 검색


**관련 이슈** 
> [FEAT] 동아리 검색 구현 https://github.com/In-lyeog-sa-mu-so/jjoin-server/issues/26

**고려해봐야할 부분**

> 검색 조건으로 여러개의 태그를 설정할 경우 검색시에 해당 태그를 하나라도 만족하는(OR) 동아리들을 검색해오도록 구현을 했는데, 여러개의 태그를 모두 만족하는(AND) 동아리만 검색해오는게 좀 더 맞는 것 같기도해서 수정할까 고민 중입니다.
그러나 태그를 만들때 서로 관련성 없는 태그로 만들면 기존의 방식(OR)로 해도 상관없을 것 같습니다.