### PR TITLE
✨ Feat : App - 일정 상세 및 사진첩 상세 API 구현

### DIFF
--- a/src/main/java/org/dongguk/jjoin/controller/ClubController.java
+++ b/src/main/java/org/dongguk/jjoin/controller/ClubController.java
@@ -43,6 +43,12 @@ public class ClubController {
         return scheduleService.readClubSchedules(userId, clubId, page);
     }
 
+    @GetMapping("/{clubId}/schedules/{scheduleId}")
+    public ClubScheduleDetailDto readClubScheduleDetail(@PathVariable Long clubId, @PathVariable Long scheduleId) {
+        Long userId = 1L;
+        return scheduleService.readClubScheduleDetail(userId, clubId, scheduleId);
+    }
+
     @GetMapping("/{clubId}/albums")
     public List<ClubAlbumDto> readClubAlbumList(@PathVariable Long clubId, @RequestParam("page") Long page) {
         return albumService.readClubAlbumList(clubId, page);

--- a/src/main/java/org/dongguk/jjoin/controller/ClubController.java
+++ b/src/main/java/org/dongguk/jjoin/controller/ClubController.java
@@ -54,6 +54,11 @@ public class ClubController {
         return albumService.readClubAlbumList(clubId, page);
     }
 
+    @GetMapping("/{clubId}/albums/{albumId}")
+    public ClubAlbumDetailDto readClubAlbumDetail(@PathVariable Long clubId, @PathVariable Long albumId) {
+        return albumService.readClubAlbumDetail(clubId, albumId);
+    }
+
     @GetMapping("/recommends")
     public List<ClubRecommendDto> readClubRecommend(@RequestBody List<UserTagDto> userTagDtoList) {
         Long userId = 2L;

--- a/src/main/java/org/dongguk/jjoin/dto/response/ClubAlbumDetailDto.java
+++ b/src/main/java/org/dongguk/jjoin/dto/response/ClubAlbumDetailDto.java
@@ -1,0 +1,21 @@
+package org.dongguk.jjoin.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.sql.Timestamp;
+import java.util.List;
+
+@Getter
+public class ClubAlbumDetailDto {
+    private Long albumId;
+    private List<String> imageUuidList;
+    private Timestamp createdDate;
+
+    @Builder
+    public ClubAlbumDetailDto(Long albumId, List<String> imageUuidList, Timestamp createdDate) {
+        this.albumId = albumId;
+        this.imageUuidList = imageUuidList;
+        this.createdDate = createdDate;
+    }
+}

--- a/src/main/java/org/dongguk/jjoin/dto/response/ClubScheduleDetailDto.java
+++ b/src/main/java/org/dongguk/jjoin/dto/response/ClubScheduleDetailDto.java
@@ -1,0 +1,32 @@
+package org.dongguk.jjoin.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.sql.Timestamp;
+
+@Getter
+public class ClubScheduleDetailDto {
+    private Long planId;
+    private String clubName;
+    private String title;
+    private String content;
+    private Timestamp startDate;
+    private Timestamp endDate;
+    private Timestamp createdDate;
+    private Timestamp updatedDate;
+    private Boolean isAgreed;
+
+    @Builder
+    public ClubScheduleDetailDto(Long planId, String clubName, String title, String content, Timestamp startDate, Timestamp endDate, Timestamp createdDate, Timestamp updatedDate, Boolean isAgreed) {
+        this.planId = planId;
+        this.clubName = clubName;
+        this.title = title;
+        this.content = content;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.createdDate = createdDate;
+        this.updatedDate = updatedDate;
+        this.isAgreed = isAgreed;
+    }
+}

--- a/src/main/java/org/dongguk/jjoin/service/AlbumService.java
+++ b/src/main/java/org/dongguk/jjoin/service/AlbumService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.dongguk.jjoin.domain.Album;
 import org.dongguk.jjoin.domain.Club;
+import org.dongguk.jjoin.dto.response.ClubAlbumDetailDto;
 import org.dongguk.jjoin.dto.response.ClubAlbumDto;
 import org.dongguk.jjoin.repository.AlbumRepository;
 import org.dongguk.jjoin.repository.ClubRepository;
@@ -34,5 +35,17 @@ public class AlbumService {
         }
 
         return clubAlbumDtoList;
+    }
+
+    public ClubAlbumDetailDto readClubAlbumDetail(Long clubId, Long albumId) {
+        Album album = albumRepository.findById(albumId).get();
+        List<String> imageUuidList = new ArrayList<>();
+        album.getImages().forEach(image -> imageUuidList.add(image.getUuidName()));
+
+        return ClubAlbumDetailDto.builder()
+                .albumId(albumId)
+                .imageUuidList(imageUuidList)
+                .createdDate(album.getCreateDate())
+                .build();
     }
 }

--- a/src/main/java/org/dongguk/jjoin/service/ScheduleService.java
+++ b/src/main/java/org/dongguk/jjoin/service/ScheduleService.java
@@ -6,6 +6,7 @@ import org.dongguk.jjoin.domain.Plan;
 import org.dongguk.jjoin.domain.Schedule;
 import org.dongguk.jjoin.domain.User;
 import org.dongguk.jjoin.dto.request.ScheduleDecideDto;
+import org.dongguk.jjoin.dto.response.ClubScheduleDetailDto;
 import org.dongguk.jjoin.dto.response.ClubScheduleDto;
 import org.dongguk.jjoin.dto.response.ScheduleDayDto;
 import org.dongguk.jjoin.dto.response.ScheduleDaysDto;
@@ -111,5 +112,22 @@ public class ScheduleService {
         }
 
         return clubScheduleDtoList;
+    }
+
+    public ClubScheduleDetailDto readClubScheduleDetail(Long userId, Long clubId, Long scheduleId) {
+        Schedule schedule = scheduleRepository.findById(scheduleId).get();
+        Plan plan = schedule.getPlan();
+
+        return ClubScheduleDetailDto.builder()
+                .planId(plan.getId())
+                .clubName(clubRepository.findById(clubId).get().getName())
+                .title(plan.getTitle())
+                .content(plan.getContent())
+                .startDate(plan.getStartDate())
+                .endDate(plan.getEndDate())
+                .createdDate(plan.getCreatedDate())
+                .updatedDate(plan.getUpdatedDate())
+                .isAgreed(schedule.getIsAgreed())
+                .build();
     }
 }


### PR DESCRIPTION
앱 화면에서 일정 및 사진첩 상세페이지로 보여줄 화면에 필요한 API를 구현합니다.

- 일정 상세정보
- 사진 리스트 및 사진첩 생성 일자


**관련 이슈** 
> [FEAT] 일정, 사진첩 상세페이지 API 구현 https://github.com/In-lyeog-sa-mu-so/jjoin-server/issues/30

**고려해봐야할 부분**

> 이미지를 넘겨주는 부분에서 이미지의 uuid만 넘겨주면 되는지 잘 모르겠습니다. 이미지 업로드 방식에 대해서 공부한 후에 다시 수정하도록 하겠습니다.