### PR TITLE
✨ Feat : Web - 동아리 멤버 관리 API 구현

### DIFF
--- a/src/main/java/org/dongguk/jjoin/controller/ManagerController.java
+++ b/src/main/java/org/dongguk/jjoin/controller/ManagerController.java
@@ -2,6 +2,7 @@ package org.dongguk.jjoin.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.dongguk.jjoin.dto.request.NoticeRequestDto;
+import org.dongguk.jjoin.dto.response.ClubMemberDtoByWeb;
 import org.dongguk.jjoin.dto.response.NoticeDto;
 import org.dongguk.jjoin.dto.response.NoticeListDto;
 import org.dongguk.jjoin.service.ManagerService;
@@ -20,6 +21,7 @@ public class ManagerController {
         Long userId = 1L;   //  로그인 구현시 @GetUser 같은 어노테이션으로 대체해야함
         managerService.createNotice(userId, clubId, noticeRequestDto);
     }
+
     @GetMapping("/club/{clubId}/notice")
     public List<NoticeListDto> showNoticeList(@PathVariable Long clubId, @RequestParam("page") Integer page, @RequestParam("size") Integer size){
         return managerService.showNoticeList(clubId, page, size);
@@ -39,5 +41,11 @@ public class ManagerController {
     public Boolean deleteNotice(@PathVariable Long clubId, @PathVariable Long noticeId){
         managerService.deleteNotice(clubId, noticeId);
         return Boolean.TRUE;
+    }
+
+    // 동아리 멤버 목록 조회
+    @GetMapping("/club/{clubId}/member")
+    public List<ClubMemberDtoByWeb> readClubMembers(@PathVariable Long clubId, @RequestParam("page") Integer page, @RequestParam("size") Integer size){
+        return managerService.readClubMembers(clubId, page, size);
     }
 }

--- a/src/main/java/org/dongguk/jjoin/controller/ManagerController.java
+++ b/src/main/java/org/dongguk/jjoin/controller/ManagerController.java
@@ -1,6 +1,7 @@
 package org.dongguk.jjoin.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.dongguk.jjoin.domain.User;
 import org.dongguk.jjoin.dto.request.NoticeRequestDto;
 import org.dongguk.jjoin.dto.response.ClubMemberDtoByWeb;
 import org.dongguk.jjoin.dto.response.NoticeDto;
@@ -47,5 +48,17 @@ public class ManagerController {
     @GetMapping("/club/{clubId}/member")
     public List<ClubMemberDtoByWeb> readClubMembers(@PathVariable Long clubId, @RequestParam("page") Integer page, @RequestParam("size") Integer size){
         return managerService.readClubMembers(clubId, page, size);
+    }
+
+    // 동아리 멤버 권한 수정
+    @PatchMapping("/club/{clubId}/member/{userId}")
+    public void modifyMemberRole(@PathVariable Long clubId, @PathVariable Long userId){
+
+    }
+
+    // 동아리 멤버 퇴출
+    @DeleteMapping("/club/{clubId}/member/{userId}")
+    public void deleteMember(@PathVariable Long clubId, @PathVariable List<Long> userId){
+        managerService.deleteMember(clubId, userId);
     }
 }

--- a/src/main/java/org/dongguk/jjoin/controller/ManagerController.java
+++ b/src/main/java/org/dongguk/jjoin/controller/ManagerController.java
@@ -2,6 +2,7 @@ package org.dongguk.jjoin.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.dongguk.jjoin.domain.User;
+import org.dongguk.jjoin.domain.type.RankType;
 import org.dongguk.jjoin.dto.request.NoticeRequestDto;
 import org.dongguk.jjoin.dto.response.ClubMemberDtoByWeb;
 import org.dongguk.jjoin.dto.response.NoticeDto;
@@ -51,9 +52,9 @@ public class ManagerController {
     }
 
     // 동아리 멤버 권한 수정
-    @PatchMapping("/club/{clubId}/member/{userId}")
-    public void modifyMemberRole(@PathVariable Long clubId, @PathVariable Long userId){
-
+    @PatchMapping("/club/{clubId}/member/{userId}/rank/{rankType}")
+    public void modifyMemberRole(@PathVariable Long clubId, @PathVariable Long userId, @PathVariable String rankType){
+        managerService.modifyMemberRole(clubId, userId, rankType);
     }
 
     // 동아리 멤버 퇴출

--- a/src/main/java/org/dongguk/jjoin/domain/ClubMember.java
+++ b/src/main/java/org/dongguk/jjoin/domain/ClubMember.java
@@ -43,4 +43,8 @@ public class ClubMember {
         this.rankType = rankType;
         this.registerDate = Timestamp.valueOf(LocalDateTime.now());
     }
+
+    public void modifyRank(RankType rankType){
+        this.rankType = rankType;
+    }
 }

--- a/src/main/java/org/dongguk/jjoin/domain/User.java
+++ b/src/main/java/org/dongguk/jjoin/domain/User.java
@@ -42,6 +42,9 @@ public class User {
     @Enumerated(EnumType.STRING)
     private MajorType major;
 
+    @Column(name = "student_id", nullable = false)
+    private Long studentId;
+
     @Column(name = "introduction")
     private String introduction;
 
@@ -83,12 +86,13 @@ public class User {
 
     @Builder
     public User(ELoginProvider provider, String serialId, String password, String name, MajorType major,
-                String introduction, String email, EUserRole role) {
+                Long studentId, String introduction, String email, EUserRole role) {
         this.provider = provider;
         this.serialId = serialId;
         this.password = password;
         this.name = name;
         this.major = major;
+        this.studentId = studentId;
         this.introduction = introduction;
         this.email = email;
         this.role = role;

--- a/src/main/java/org/dongguk/jjoin/dto/response/ClubMemberDtoByWeb.java
+++ b/src/main/java/org/dongguk/jjoin/dto/response/ClubMemberDtoByWeb.java
@@ -1,0 +1,29 @@
+package org.dongguk.jjoin.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.dongguk.jjoin.domain.type.DependentType;
+import org.dongguk.jjoin.domain.type.MajorType;
+import org.dongguk.jjoin.domain.type.RankType;
+
+import java.sql.Timestamp;
+
+@Getter
+public class ClubMemberDtoByWeb {
+    private Long userId;
+    private String userName;
+    private Long studentId;
+    private MajorType major;
+    private Timestamp registerDate;
+    private RankType position;
+
+    @Builder
+    public ClubMemberDtoByWeb(Long userId, String userName, MajorType major, Long studentId, Timestamp registerDate, RankType position) {
+        this.userId = userId;
+        this.userName = userName;
+        this.major = major;
+        this.studentId = studentId;
+        this.registerDate = registerDate;
+        this.position = position;
+    }
+}

--- a/src/main/java/org/dongguk/jjoin/repository/ClubMemberRepository.java
+++ b/src/main/java/org/dongguk/jjoin/repository/ClubMemberRepository.java
@@ -3,6 +3,8 @@ package org.dongguk.jjoin.repository;
 import org.dongguk.jjoin.domain.Club;
 import org.dongguk.jjoin.domain.ClubMember;
 import org.dongguk.jjoin.domain.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -12,8 +14,10 @@ import java.util.List;
 
 @Repository
 public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
-
     @Query(value = "SELECT c FROM ClubMember AS cm INNER JOIN Club AS c ON cm.club = c WHERE cm.user = :user")
     List<Club> findUserClubsByUser(@Param("user") User user);
+
     Long countAllByClub(Club club);
+
+    List<ClubMember> findByClubId(Long clubId, Pageable pageable);
 }

--- a/src/main/java/org/dongguk/jjoin/repository/ClubMemberRepository.java
+++ b/src/main/java/org/dongguk/jjoin/repository/ClubMemberRepository.java
@@ -3,9 +3,11 @@ package org.dongguk.jjoin.repository;
 import org.dongguk.jjoin.domain.Club;
 import org.dongguk.jjoin.domain.ClubMember;
 import org.dongguk.jjoin.domain.User;
+import org.dongguk.jjoin.domain.type.RankType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -20,4 +22,10 @@ public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
     Long countAllByClub(Club club);
 
     List<ClubMember> findByClubId(Long clubId, Pageable pageable);
+
+    ClubMember findByUser(User user);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM ClubMember AS cm WHERE cm.club.id = :clubId AND cm.user.id IN :userIds")
+    void deleteAllByClubIdAndUserId(Long clubId, List<Long> userIds);
 }

--- a/src/main/java/org/dongguk/jjoin/repository/ClubMemberRepository.java
+++ b/src/main/java/org/dongguk/jjoin/repository/ClubMemberRepository.java
@@ -13,6 +13,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
@@ -24,6 +25,9 @@ public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
     List<ClubMember> findByClubId(Long clubId, Pageable pageable);
 
     ClubMember findByUser(User user);
+
+    @Query("SELECT cm FROM ClubMember AS cm WHERE cm.club.id = :clubId AND cm.user.id = :userId")
+    Optional<ClubMember> findClubMemberByClubIdAndUserId(Long clubId, Long userId);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("DELETE FROM ClubMember AS cm WHERE cm.club.id = :clubId AND cm.user.id IN :userIds")

--- a/src/main/java/org/dongguk/jjoin/service/ManagerService.java
+++ b/src/main/java/org/dongguk/jjoin/service/ManagerService.java
@@ -6,6 +6,7 @@ import org.dongguk.jjoin.domain.Club;
 import org.dongguk.jjoin.domain.ClubMember;
 import org.dongguk.jjoin.domain.Notice;
 import org.dongguk.jjoin.domain.User;
+import org.dongguk.jjoin.domain.type.RankType;
 import org.dongguk.jjoin.dto.request.NoticeRequestDto;
 import org.dongguk.jjoin.dto.response.ClubMemberDtoByWeb;
 import org.dongguk.jjoin.dto.response.NoticeDto;
@@ -16,6 +17,7 @@ import org.dongguk.jjoin.repository.NoticeRepository;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.PathVariable;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -109,5 +111,14 @@ public class ManagerService {
                     .build());
         }
         return clubMemberDtoByWebs;
+    }
+
+    // 동아리 멤버 퇴출
+    public void deleteMember(Long clubId, List<Long> userIds){
+//        User user = GetUser();
+//        if (clubMemberRepository.findByUser(user).getRankType().equals(RankType.LEADER)){
+//            throw new RuntimeException("권한 없어용");
+//        }
+        clubMemberRepository.deleteAllByClubIdAndUserId(clubId, userIds);
     }
 }

--- a/src/main/java/org/dongguk/jjoin/service/ManagerService.java
+++ b/src/main/java/org/dongguk/jjoin/service/ManagerService.java
@@ -113,6 +113,16 @@ public class ManagerService {
         return clubMemberDtoByWebs;
     }
 
+    // 동아리 멤버 권한 수정
+    public void modifyMemberRole(Long clubId, Long userId, String rankType){
+        //        User user = GetUser();
+//        if (clubMemberRepository.findByUser(user).getRankType().equals(RankType.LEADER)){
+//            throw new RuntimeException("권한 없어용");
+//        }
+        ClubMember clubMember = clubMemberRepository.findClubMemberByClubIdAndUserId(clubId, userId).orElseThrow(()-> new RuntimeException("No clubMember"));
+        clubMember.modifyRank(RankType.valueOf(rankType));
+    }
+
     // 동아리 멤버 퇴출
     public void deleteMember(Long clubId, List<Long> userIds){
 //        User user = GetUser();

--- a/src/main/java/org/dongguk/jjoin/service/ManagerService.java
+++ b/src/main/java/org/dongguk/jjoin/service/ManagerService.java
@@ -3,15 +3,16 @@ package org.dongguk.jjoin.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.dongguk.jjoin.domain.Club;
+import org.dongguk.jjoin.domain.ClubMember;
 import org.dongguk.jjoin.domain.Notice;
+import org.dongguk.jjoin.domain.User;
 import org.dongguk.jjoin.dto.request.NoticeRequestDto;
+import org.dongguk.jjoin.dto.response.ClubMemberDtoByWeb;
 import org.dongguk.jjoin.dto.response.NoticeDto;
 import org.dongguk.jjoin.dto.response.NoticeListDto;
-import org.dongguk.jjoin.dto.response.NoticeListDtoByApp;
+import org.dongguk.jjoin.repository.ClubMemberRepository;
 import org.dongguk.jjoin.repository.ClubRepository;
 import org.dongguk.jjoin.repository.NoticeRepository;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,6 +29,7 @@ import java.util.Optional;
 public class ManagerService {
     private final ClubRepository clubRepository;
     private final NoticeRepository noticeRepository;
+    private final ClubMemberRepository clubMemberRepository;
 
     public List<NoticeListDto> showNoticeList(Long clubId, Integer page, Integer size){
         Club club = clubRepository.findById(clubId).orElseThrow(()-> new RuntimeException("no match clubId"));
@@ -88,5 +90,24 @@ public class ManagerService {
         Notice notice = searchNotice(clubId, noticeId);
         notice.deleteNotice();
         return Boolean.TRUE;
+    }
+
+    // 동아리 멤버 목록 조회
+    public List<ClubMemberDtoByWeb> readClubMembers(Long clubId, Integer page, Integer size){
+        PageRequest pageRequest = PageRequest.of(page, size);
+        List<ClubMember> clubMembers = clubMemberRepository.findByClubId(clubId, pageRequest);
+        List<ClubMemberDtoByWeb> clubMemberDtoByWebs = new ArrayList<>();
+        for (ClubMember cm : clubMembers){
+            User user = cm.getUser();
+            clubMemberDtoByWebs.add(ClubMemberDtoByWeb.builder()
+                            .userId(user.getId())
+                            .userName(user.getName())
+                            .major(user.getMajor())
+                            .studentId(user.getStudentId())
+                            .registerDate(cm.getRegisterDate())
+                            .position(cm.getRankType())
+                    .build());
+        }
+        return clubMemberDtoByWebs;
     }
 }


### PR DESCRIPTION
관리자 웹에서 동아리 관리자가 본인의 동아리 멤버 목록, 권한, 퇴출하는 기능을 구현합니다.
추가로 User table에 학번 정보를 저장할 student_Id column을 추가하여 커밋하였습니다.

- 멤버 목록
- 멤버 권한 수정
- 멤버 퇴출

**관련 이슈 **
> #33 

**고려해봐야할 사항**
>  해당 기능을 사용하기 위해 로그인된 유저의 권한을 확인하는 부분이 추가되어야합니다.
