### PR TITLE
✨ Feat : App - 일정 API 구현

### DIFF
--- a/src/main/java/org/dongguk/jjoin/controller/ManagerController.java
+++ b/src/main/java/org/dongguk/jjoin/controller/ManagerController.java
@@ -4,7 +4,9 @@ import lombok.RequiredArgsConstructor;
 import org.dongguk.jjoin.dto.request.NoticeRequestDto;
 import org.dongguk.jjoin.dto.response.NoticeDto;
 import org.dongguk.jjoin.dto.response.NoticeListDto;
+import org.dongguk.jjoin.dto.response.PlanDto;
 import org.dongguk.jjoin.service.ManagerService;
+import org.dongguk.jjoin.service.PlanService;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -14,6 +16,7 @@ import java.util.List;
 @RequestMapping("/manager")
 public class ManagerController {
     private final ManagerService managerService;
+    private final PlanService planService;
 
     @PostMapping("/club/{clubId}/notice")
     public void createNotice(@PathVariable Long clubId, @RequestBody NoticeRequestDto noticeRequestDto){
@@ -39,5 +42,10 @@ public class ManagerController {
     public Boolean deleteNotice(@PathVariable Long clubId, @PathVariable Long noticeId){
         managerService.deleteNotice(clubId, noticeId);
         return Boolean.TRUE;
+    }
+
+    @GetMapping("/club/{clubId}/plan")
+    public List<PlanDto> readPlanList(@PathVariable Long clubId) {
+        return planService.readPlanList(clubId);
     }
 }

--- a/src/main/java/org/dongguk/jjoin/controller/ManagerController.java
+++ b/src/main/java/org/dongguk/jjoin/controller/ManagerController.java
@@ -2,6 +2,8 @@ package org.dongguk.jjoin.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.dongguk.jjoin.dto.request.NoticeRequestDto;
+import org.dongguk.jjoin.dto.request.PlanRequestDto;
+import org.dongguk.jjoin.dto.request.PlanUpdateDto;
 import org.dongguk.jjoin.dto.response.NoticeDto;
 import org.dongguk.jjoin.dto.response.NoticeListDto;
 import org.dongguk.jjoin.dto.response.PlanDto;
@@ -47,5 +49,15 @@ public class ManagerController {
     @GetMapping("/club/{clubId}/plan")
     public List<PlanDto> readPlanList(@PathVariable Long clubId) {
         return planService.readPlanList(clubId);
+    }
+
+    @PostMapping("/club/{clubId}/plan")
+    public Boolean createPlan(@PathVariable Long clubId, @RequestBody PlanRequestDto planRequestDto) {
+        return planService.createPlan(clubId, planRequestDto);
+    }
+
+    @PutMapping("/club/{clubId}/plan/{planId}")
+    public Boolean updatePlan(@RequestBody PlanUpdateDto planUpdateDto) {
+        return planService.updatePlan(planUpdateDto);
     }
 }

--- a/src/main/java/org/dongguk/jjoin/controller/ManagerController.java
+++ b/src/main/java/org/dongguk/jjoin/controller/ManagerController.java
@@ -60,4 +60,9 @@ public class ManagerController {
     public Boolean updatePlan(@RequestBody PlanUpdateDto planUpdateDto) {
         return planService.updatePlan(planUpdateDto);
     }
+
+    @DeleteMapping("/club/{clubId}/plan/{planId}")
+    public Boolean deletePlan(@PathVariable Long planId) {
+        return planService.deletePlan(planId);
+    }
 }

--- a/src/main/java/org/dongguk/jjoin/domain/Plan.java
+++ b/src/main/java/org/dongguk/jjoin/domain/Plan.java
@@ -29,7 +29,7 @@ public class Plan {
     @Column(name = "created_date", nullable = false)
     private Timestamp createdDate;
 
-    @Column(name = "updated_date")
+    @Column(name = "updated_date", nullable = false)
     private Timestamp updatedDate;
 
     @Column(name = "start_date", nullable = false)
@@ -53,6 +53,7 @@ public class Plan {
     public Plan(Club club, Timestamp startDate, Timestamp endDate, String title, String content) {
         this.club = club;
         this.createdDate = Timestamp.valueOf(LocalDateTime.now());
+        this.updatedDate = Timestamp.valueOf(LocalDateTime.now());
         this.startDate = startDate;
         this.endDate = endDate;
         this.title = title;

--- a/src/main/java/org/dongguk/jjoin/domain/Plan.java
+++ b/src/main/java/org/dongguk/jjoin/domain/Plan.java
@@ -47,7 +47,7 @@ public class Plan {
 
     //--------------------------------------------------------
 
-    @OneToMany(mappedBy = "plan", fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "plan", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     List<Schedule> schedules = new ArrayList<>();
 
     @Builder

--- a/src/main/java/org/dongguk/jjoin/domain/Plan.java
+++ b/src/main/java/org/dongguk/jjoin/domain/Plan.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.dongguk.jjoin.dto.request.PlanUpdateDto;
 
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
@@ -58,5 +59,13 @@ public class Plan {
         this.endDate = endDate;
         this.title = title;
         this.content = content;
+    }
+
+    public void updatePlan(PlanUpdateDto planUpdateDto) {
+        this.title = planUpdateDto.getTitle();
+        this.content = planUpdateDto.getContent();
+        this.startDate = planUpdateDto.getStartDate();
+        this.endDate = planUpdateDto.getEndDate();
+        this.updatedDate = Timestamp.valueOf(LocalDateTime.now());
     }
 }

--- a/src/main/java/org/dongguk/jjoin/dto/request/PlanRequestDto.java
+++ b/src/main/java/org/dongguk/jjoin/dto/request/PlanRequestDto.java
@@ -1,0 +1,24 @@
+package org.dongguk.jjoin.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.sql.Timestamp;
+
+@Getter
+public class PlanRequestDto {
+    private Long clubId;
+    private String title;
+    private String content;
+    private Timestamp startDate;
+    private Timestamp endDate;
+
+    @Builder
+    public PlanRequestDto(Long clubId, String title, String content, Timestamp startDate, Timestamp endDate) {
+        this.clubId = clubId;
+        this.title = title;
+        this.content = content;
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+}

--- a/src/main/java/org/dongguk/jjoin/dto/request/PlanUpdateDto.java
+++ b/src/main/java/org/dongguk/jjoin/dto/request/PlanUpdateDto.java
@@ -1,0 +1,24 @@
+package org.dongguk.jjoin.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.sql.Timestamp;
+
+@Getter
+public class PlanUpdateDto {
+    private Long id;
+    private String title;
+    private String content;
+    private Timestamp startDate;
+    private Timestamp endDate;
+
+    @Builder
+    public PlanUpdateDto(Long id, String title, String content, Timestamp startDate, Timestamp endDate) {
+        this.id = id;
+        this.title = title;
+        this.content = content;
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+}

--- a/src/main/java/org/dongguk/jjoin/dto/response/PlanDto.java
+++ b/src/main/java/org/dongguk/jjoin/dto/response/PlanDto.java
@@ -1,0 +1,28 @@
+package org.dongguk.jjoin.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.sql.Timestamp;
+
+@Getter
+public class PlanDto {
+    private Long id;
+    private String clubName;
+    private String title;
+    private String content;
+    private Timestamp startDate;
+    private Timestamp endDate;
+    private Timestamp updatedDate;
+
+    @Builder
+    public PlanDto(Long id, String clubName, String title, String content, Timestamp startDate, Timestamp endDate, Timestamp updatedDate) {
+        this.id = id;
+        this.clubName = clubName;
+        this.title = title;
+        this.content = content;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.updatedDate = updatedDate;
+    }
+}

--- a/src/main/java/org/dongguk/jjoin/service/PlanService.java
+++ b/src/main/java/org/dongguk/jjoin/service/PlanService.java
@@ -1,0 +1,43 @@
+package org.dongguk.jjoin.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.dongguk.jjoin.domain.Club;
+import org.dongguk.jjoin.domain.Plan;
+import org.dongguk.jjoin.dto.response.PlanDto;
+import org.dongguk.jjoin.repository.ClubRepository;
+import org.dongguk.jjoin.repository.PlanRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+public class PlanService {
+    private final PlanRepository planRepository;
+    private final ClubRepository clubRepository;
+
+    public List<PlanDto> readPlanList(Long clubId) {
+        Club club = clubRepository.findById(clubId).get();
+        List<Plan> planList = planRepository.findByClub(club);
+        List<PlanDto> planDtoList = new ArrayList<>();
+
+        for (Plan plan : planList) {
+            planDtoList.add(PlanDto.builder()
+                            .id(plan.getId())
+                            .clubName(club.getName())
+                            .title(plan.getTitle())
+                            .content(plan.getContent())
+                            .startDate(plan.getStartDate())
+                            .endDate(plan.getEndDate())
+                            .updatedDate(plan.getUpdatedDate())
+                    .build());
+        }
+
+        return  planDtoList;
+    }
+}

--- a/src/main/java/org/dongguk/jjoin/service/PlanService.java
+++ b/src/main/java/org/dongguk/jjoin/service/PlanService.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.dongguk.jjoin.domain.Club;
 import org.dongguk.jjoin.domain.Plan;
 import org.dongguk.jjoin.dto.request.PlanRequestDto;
+import org.dongguk.jjoin.dto.request.PlanUpdateDto;
 import org.dongguk.jjoin.dto.response.PlanDto;
 import org.dongguk.jjoin.repository.ClubRepository;
 import org.dongguk.jjoin.repository.PlanRepository;
@@ -53,6 +54,13 @@ public class PlanService {
                         .startDate(planRequestDto.getStartDate())
                         .endDate(planRequestDto.getEndDate())
                 .build());
+
+        return Boolean.TRUE;
+    }
+
+    public Boolean updatePlan(PlanUpdateDto planRequestDto) {
+        Plan plan = planRepository.findById(planRequestDto.getId()).get();
+        plan.updatePlan(planRequestDto);
 
         return Boolean.TRUE;
     }

--- a/src/main/java/org/dongguk/jjoin/service/PlanService.java
+++ b/src/main/java/org/dongguk/jjoin/service/PlanService.java
@@ -4,12 +4,14 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.dongguk.jjoin.domain.Club;
 import org.dongguk.jjoin.domain.Plan;
+import org.dongguk.jjoin.dto.request.PlanRequestDto;
 import org.dongguk.jjoin.dto.response.PlanDto;
 import org.dongguk.jjoin.repository.ClubRepository;
 import org.dongguk.jjoin.repository.PlanRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -39,5 +41,19 @@ public class PlanService {
         }
 
         return  planDtoList;
+    }
+
+    public Boolean createPlan(Long clubId, PlanRequestDto planRequestDto) {
+        Club club = clubRepository.findById(clubId).get();
+
+        planRepository.save(Plan.builder()
+                        .club(club)
+                        .title(planRequestDto.getTitle())
+                        .content(planRequestDto.getContent())
+                        .startDate(planRequestDto.getStartDate())
+                        .endDate(planRequestDto.getEndDate())
+                .build());
+
+        return Boolean.TRUE;
     }
 }

--- a/src/main/java/org/dongguk/jjoin/service/PlanService.java
+++ b/src/main/java/org/dongguk/jjoin/service/PlanService.java
@@ -64,4 +64,9 @@ public class PlanService {
 
         return Boolean.TRUE;
     }
+
+    public Boolean deletePlan(Long planId) {
+        planRepository.deleteById(planId);
+        return Boolean.TRUE;
+    }
 }


### PR DESCRIPTION
웹 일정 화면에 필요한 API를 구현합니다.

- 일정 목록 조회
- 일정 추가
- 일정 수정
- 일정 삭


**관련 이슈** 
> [FEAT] Web - 동아리 일정 API 구현 https://github.com/In-lyeog-sa-mu-so/jjoin-server/issues/42

**고려해봐야할 부분**

> 일정 삭제 부분에서 일정 삭제를 hard delete 방식으로 삭제를 진행했습니다. 이를 plan에 단순히 isDeleted를 추가해서 soft delete 방식으로 바꿀건지 논의가 필요합니다.