### PR TITLE
✨ Feat : Web - 일정 API 구현

### DIFF
--- a/src/main/java/org/dongguk/jjoin/controller/AdminController.java
+++ b/src/main/java/org/dongguk/jjoin/controller/AdminController.java
@@ -1,0 +1,24 @@
+package org.dongguk.jjoin.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.dongguk.jjoin.dto.response.EnrollmentDto;
+import org.dongguk.jjoin.service.EnrollmentService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin")
+public class AdminController {
+    private final EnrollmentService enrollmentService;
+
+    @GetMapping("/enrollment")
+    public List<EnrollmentDto> readEnrollmentList() {
+        return enrollmentService.readEnrollmentList();
+    }
+}

--- a/src/main/java/org/dongguk/jjoin/controller/AdminController.java
+++ b/src/main/java/org/dongguk/jjoin/controller/AdminController.java
@@ -25,4 +25,9 @@ public class AdminController {
     public Boolean updateEnrollmentList(@RequestBody EnrollmentUpdateDto enrollmentUpdateDto) {
         return enrollmentService.updateEnrollmentList(enrollmentUpdateDto);
     }
+
+    @DeleteMapping("/enrollment")
+    public Boolean deleteEnrollmentList(@RequestBody EnrollmentUpdateDto enrollmentUpdateDto) {
+        return enrollmentService.deleteEnrollmentList(enrollmentUpdateDto);
+    }
 }

--- a/src/main/java/org/dongguk/jjoin/controller/AdminController.java
+++ b/src/main/java/org/dongguk/jjoin/controller/AdminController.java
@@ -2,11 +2,10 @@ package org.dongguk.jjoin.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.dongguk.jjoin.dto.request.EnrollmentUpdateDto;
 import org.dongguk.jjoin.dto.response.EnrollmentDto;
 import org.dongguk.jjoin.service.EnrollmentService;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -20,5 +19,10 @@ public class AdminController {
     @GetMapping("/enrollment")
     public List<EnrollmentDto> readEnrollmentList() {
         return enrollmentService.readEnrollmentList();
+    }
+
+    @PutMapping("/enrollment")
+    public Boolean updateEnrollmentList(@RequestBody EnrollmentUpdateDto enrollmentUpdateDto) {
+        return enrollmentService.updateEnrollmentList(enrollmentUpdateDto);
     }
 }

--- a/src/main/java/org/dongguk/jjoin/domain/Club.java
+++ b/src/main/java/org/dongguk/jjoin/domain/Club.java
@@ -75,4 +75,8 @@ public class Club {
         this.clubImage = clubImage;
         this.backgroundImage = backgroundImage;
     }
+
+    public void enrollClub() {
+        this.createdDate = Timestamp.valueOf(LocalDateTime.now());
+    }
 }

--- a/src/main/java/org/dongguk/jjoin/domain/Enrollment.java
+++ b/src/main/java/org/dongguk/jjoin/domain/Enrollment.java
@@ -21,15 +21,15 @@ public class Enrollment {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
-    private User user;
+    @JoinColumn(name = "club_id", nullable = false)
+    private Club club;
 
     @Column(name = "created_date")
     private Timestamp createdDate;
 
     @Builder
-    public Enrollment(User user) {
-        this.user = user;
+    public Enrollment(Club club) {
+        this.club = club;
         this.createdDate = Timestamp.valueOf(LocalDateTime.now());
     }
 }

--- a/src/main/java/org/dongguk/jjoin/domain/User.java
+++ b/src/main/java/org/dongguk/jjoin/domain/User.java
@@ -85,9 +85,6 @@ public class User {
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
     List<Image> images = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
-    List<Enrollment> enrollments = new ArrayList<>();
-
     @Builder
     public User(ELoginProvider provider, String serialId, String password, String name, MajorType major,
                 Long studentId, String introduction, String email, EUserRole role) {

--- a/src/main/java/org/dongguk/jjoin/dto/request/EnrollmentUpdateDto.java
+++ b/src/main/java/org/dongguk/jjoin/dto/request/EnrollmentUpdateDto.java
@@ -1,0 +1,14 @@
+package org.dongguk.jjoin.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class EnrollmentUpdateDto {
+    private List<Long> id;
+}

--- a/src/main/java/org/dongguk/jjoin/dto/response/EnrollmentDto.java
+++ b/src/main/java/org/dongguk/jjoin/dto/response/EnrollmentDto.java
@@ -8,13 +8,15 @@ import java.util.List;
 
 @Getter
 public class EnrollmentDto {
+    private Long id;
     private String clubName;
     private String dependent;
     private List<String> tags;
     private Timestamp createdDate;
 
     @Builder
-    public EnrollmentDto(String clubName, String dependent, List<String> tags, Timestamp createdDate) {
+    public EnrollmentDto(Long id, String clubName, String dependent, List<String> tags, Timestamp createdDate) {
+        this.id = id;
         this.clubName = clubName;
         this.dependent = dependent;
         this.tags = tags;

--- a/src/main/java/org/dongguk/jjoin/dto/response/EnrollmentDto.java
+++ b/src/main/java/org/dongguk/jjoin/dto/response/EnrollmentDto.java
@@ -1,0 +1,23 @@
+package org.dongguk.jjoin.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.sql.Timestamp;
+import java.util.List;
+
+@Getter
+public class EnrollmentDto {
+    private String clubName;
+    private String dependent;
+    private List<String> tags;
+    private Timestamp createdDate;
+
+    @Builder
+    public EnrollmentDto(String clubName, String dependent, List<String> tags, Timestamp createdDate) {
+        this.clubName = clubName;
+        this.dependent = dependent;
+        this.tags = tags;
+        this.createdDate = createdDate;
+    }
+}

--- a/src/main/java/org/dongguk/jjoin/repository/EnrollmentRepository.java
+++ b/src/main/java/org/dongguk/jjoin/repository/EnrollmentRepository.java
@@ -1,0 +1,9 @@
+package org.dongguk.jjoin.repository;
+
+import org.dongguk.jjoin.domain.Enrollment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
+}

--- a/src/main/java/org/dongguk/jjoin/service/EnrollmentService.java
+++ b/src/main/java/org/dongguk/jjoin/service/EnrollmentService.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.dongguk.jjoin.domain.Club;
 import org.dongguk.jjoin.domain.ClubTag;
 import org.dongguk.jjoin.domain.Enrollment;
+import org.dongguk.jjoin.dto.request.EnrollmentUpdateDto;
 import org.dongguk.jjoin.dto.response.EnrollmentDto;
 import org.dongguk.jjoin.repository.EnrollmentRepository;
 import org.springframework.stereotype.Service;
@@ -41,5 +42,16 @@ public class EnrollmentService {
         }
 
         return enrollmentDtoList;
+    }
+
+    public Boolean updateEnrollmentList(EnrollmentUpdateDto enrollmentUpdateDto) {
+        List<Long> idList = enrollmentUpdateDto.getId();
+
+        for (Long id : idList) {
+            Enrollment enrollment = enrollmentRepository.findById(id).get();
+            enrollment.getClub().enrollClub();
+        }
+
+        return true;
     }
 }

--- a/src/main/java/org/dongguk/jjoin/service/EnrollmentService.java
+++ b/src/main/java/org/dongguk/jjoin/service/EnrollmentService.java
@@ -1,0 +1,44 @@
+package org.dongguk.jjoin.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.dongguk.jjoin.domain.Club;
+import org.dongguk.jjoin.domain.ClubTag;
+import org.dongguk.jjoin.domain.Enrollment;
+import org.dongguk.jjoin.dto.response.EnrollmentDto;
+import org.dongguk.jjoin.repository.EnrollmentRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class EnrollmentService {
+    private final EnrollmentRepository enrollmentRepository;
+    public List<EnrollmentDto> readEnrollmentList() {
+        List<Enrollment> enrollmentList = enrollmentRepository.findAll();
+        List<EnrollmentDto> enrollmentDtoList = new ArrayList<>();
+
+        for (Enrollment enrollment : enrollmentList) {
+            Club club = enrollment.getClub();
+            List<ClubTag> clubTagList = club.getTags();
+            List<String> tagList = new ArrayList<>();
+            clubTagList.forEach(tags -> tagList.add(tags.getTag().getName()));
+            enrollmentDtoList.add(EnrollmentDto.builder()
+                            .clubName(club.getName())
+                            .dependent(club.getDependent().toString())
+                            .tags(tagList)
+                            .createdDate(Timestamp.valueOf(LocalDateTime.now()))
+                            .createdDate(enrollment.getCreatedDate())
+                    .build());
+        }
+
+        return enrollmentDtoList;
+    }
+}

--- a/src/main/java/org/dongguk/jjoin/service/EnrollmentService.java
+++ b/src/main/java/org/dongguk/jjoin/service/EnrollmentService.java
@@ -50,6 +50,17 @@ public class EnrollmentService {
         for (Long id : idList) {
             Enrollment enrollment = enrollmentRepository.findById(id).get();
             enrollment.getClub().enrollClub();
+            enrollmentRepository.deleteById(id);
+        }
+
+        return true;
+    }
+
+    public Boolean deleteEnrollmentList(EnrollmentUpdateDto enrollmentUpdateDto) {
+        List<Long> idList = enrollmentUpdateDto.getId();
+
+        for (Long id : idList) {
+            enrollmentRepository.deleteById(id);
         }
 
         return true;

--- a/src/main/java/org/dongguk/jjoin/service/EnrollmentService.java
+++ b/src/main/java/org/dongguk/jjoin/service/EnrollmentService.java
@@ -31,6 +31,7 @@ public class EnrollmentService {
             List<String> tagList = new ArrayList<>();
             clubTagList.forEach(tags -> tagList.add(tags.getTag().getName()));
             enrollmentDtoList.add(EnrollmentDto.builder()
+                            .id(enrollment.getId())
                             .clubName(club.getName())
                             .dependent(club.getDependent().toString())
                             .tags(tagList)


### PR DESCRIPTION
웹 일정 화면에 필요한 API를 구현합니다.

- 동아리 개설 목록 조회
- 동아리 개설 승인
- 동아리 개설 거


**관련 이슈** 
> [FEAT] Web - 동아리 개설 API 구현 https://github.com/In-lyeog-sa-mu-so/jjoin-server/issues/44

**고려해봐야할 부분**

> 동아리 개설 승인 시 이를 club의 createDate에 날짜를 할당하는 방식으로 동아리 개설을 표현했기때문에 앞서서 **동아리 조회를 할때 모두 createDate가 null이 아닌 동아리만 조회하도록 변경해야합니다.**(해당 조건이 빠질 경우 아직 개설이 되지 않은 동아리도 조회가 됨). 또한 승인 거부를 할 시 해당 데이터가 반영된 후 삭제되는데(hard delete) 이 방식에 대해서는 다시 생각해봐야할 것 같습니다.