### PR TITLE
✨ Feat : Web - 동아리 삭제 API 구현

### DIFF
--- a/src/main/java/org/dongguk/jjoin/controller/AdminController.java
+++ b/src/main/java/org/dongguk/jjoin/controller/AdminController.java
@@ -2,6 +2,7 @@ package org.dongguk.jjoin.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.dongguk.jjoin.dto.request.ClubDeletionUpdateDto;
 import org.dongguk.jjoin.dto.request.EnrollmentUpdateDto;
 import org.dongguk.jjoin.dto.response.ClubDeletionDto;
 import org.dongguk.jjoin.dto.response.EnrollmentDto;
@@ -37,5 +38,10 @@ public class AdminController {
     @GetMapping("/deletion")
     public List<ClubDeletionDto> readClubDeletionList() {
         return clubDeletionService.readClubDeletionList();
+    }
+
+    @PutMapping("/deletion")
+    public Boolean updateClubDeletion(@RequestBody ClubDeletionUpdateDto clubDeletionUpdateDto) {
+        return clubDeletionService.updateClubDeltionList(clubDeletionUpdateDto);
     }
 }

--- a/src/main/java/org/dongguk/jjoin/controller/AdminController.java
+++ b/src/main/java/org/dongguk/jjoin/controller/AdminController.java
@@ -3,7 +3,9 @@ package org.dongguk.jjoin.controller;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.dongguk.jjoin.dto.request.EnrollmentUpdateDto;
+import org.dongguk.jjoin.dto.response.ClubDeletionDto;
 import org.dongguk.jjoin.dto.response.EnrollmentDto;
+import org.dongguk.jjoin.service.ClubDeletionService;
 import org.dongguk.jjoin.service.EnrollmentService;
 import org.springframework.web.bind.annotation.*;
 
@@ -15,6 +17,7 @@ import java.util.List;
 @RequestMapping("/admin")
 public class AdminController {
     private final EnrollmentService enrollmentService;
+    private final ClubDeletionService clubDeletionService;
 
     @GetMapping("/enrollment")
     public List<EnrollmentDto> readEnrollmentList() {
@@ -29,5 +32,10 @@ public class AdminController {
     @DeleteMapping("/enrollment")
     public Boolean deleteEnrollmentList(@RequestBody EnrollmentUpdateDto enrollmentUpdateDto) {
         return enrollmentService.deleteEnrollmentList(enrollmentUpdateDto);
+    }
+
+    @GetMapping("/deletion")
+    public List<ClubDeletionDto> readClubDeletionList() {
+        return clubDeletionService.readClubDeletionList();
     }
 }

--- a/src/main/java/org/dongguk/jjoin/domain/ClubDeletion.java
+++ b/src/main/java/org/dongguk/jjoin/domain/ClubDeletion.java
@@ -29,4 +29,8 @@ public class ClubDeletion {
         this.club = club;
         this.isDeleted = false;
     }
+
+    public void deleteClub() {
+        isDeleted = true;
+    }
 }

--- a/src/main/java/org/dongguk/jjoin/dto/request/ClubDeletionUpdateDto.java
+++ b/src/main/java/org/dongguk/jjoin/dto/request/ClubDeletionUpdateDto.java
@@ -1,0 +1,14 @@
+package org.dongguk.jjoin.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ClubDeletionUpdateDto {
+    private List<Long> id;
+}

--- a/src/main/java/org/dongguk/jjoin/dto/response/ClubDeletionDto.java
+++ b/src/main/java/org/dongguk/jjoin/dto/response/ClubDeletionDto.java
@@ -1,0 +1,25 @@
+package org.dongguk.jjoin.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.sql.Timestamp;
+import java.util.List;
+
+@Getter
+public class ClubDeletionDto {
+    private Long id;
+    private String clubName;
+    private String dependent;
+    private List<String> tags;
+    private Timestamp createdDate;
+
+    @Builder
+    public ClubDeletionDto(Long id, String clubName, String dependent, List<String> tags, Timestamp createdDate) {
+        this.id = id;
+        this.clubName = clubName;
+        this.dependent = dependent;
+        this.tags = tags;
+        this.createdDate = createdDate;
+    }
+}

--- a/src/main/java/org/dongguk/jjoin/repository/ClubDeletionRepository.java
+++ b/src/main/java/org/dongguk/jjoin/repository/ClubDeletionRepository.java
@@ -1,0 +1,12 @@
+package org.dongguk.jjoin.repository;
+
+import org.dongguk.jjoin.domain.ClubDeletion;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ClubDeletionRepository extends JpaRepository<ClubDeletion, Long> {
+    List<ClubDeletion> findByIsDeletedIsFalse();
+}

--- a/src/main/java/org/dongguk/jjoin/service/ClubDeletionService.java
+++ b/src/main/java/org/dongguk/jjoin/service/ClubDeletionService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.dongguk.jjoin.domain.Club;
 import org.dongguk.jjoin.domain.ClubDeletion;
+import org.dongguk.jjoin.dto.request.ClubDeletionUpdateDto;
 import org.dongguk.jjoin.dto.response.ClubDeletionDto;
 import org.dongguk.jjoin.repository.ClubDeletionRepository;
 import org.springframework.stereotype.Service;
@@ -37,5 +38,15 @@ public class ClubDeletionService {
         }
 
         return clubDeletionDtos;
+    }
+
+    public Boolean updateClubDeltionList(ClubDeletionUpdateDto clubDeletionUpdateDto) {
+        List<Long> ids = clubDeletionUpdateDto.getId();
+
+        for (Long id : ids) {
+            clubDeletionRepository.findById(id).get().deleteClub();
+        }
+
+        return true;
     }
 }

--- a/src/main/java/org/dongguk/jjoin/service/ClubDeletionService.java
+++ b/src/main/java/org/dongguk/jjoin/service/ClubDeletionService.java
@@ -1,0 +1,41 @@
+package org.dongguk.jjoin.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.dongguk.jjoin.domain.Club;
+import org.dongguk.jjoin.domain.ClubDeletion;
+import org.dongguk.jjoin.dto.response.ClubDeletionDto;
+import org.dongguk.jjoin.repository.ClubDeletionRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ClubDeletionService {
+    private final ClubDeletionRepository clubDeletionRepository;
+
+    public List<ClubDeletionDto> readClubDeletionList() {
+        List<ClubDeletion> clubDeletions = clubDeletionRepository.findByIsDeletedIsFalse();
+        List<ClubDeletionDto> clubDeletionDtos = new ArrayList<>();
+
+        for (ClubDeletion clubDeletion : clubDeletions) {
+            Club club = clubDeletion.getClub();
+            clubDeletionDtos.add(ClubDeletionDto.builder()
+                            .id(clubDeletion.getId())
+                            .clubName(club.getName())
+                            .dependent(club.getDependent().toString())
+                            .tags(club.getTags().stream().map(clubTag -> clubTag.getTag().getName())
+                                    .collect(Collectors.toList()))
+                            .createdDate(club.getCreatedDate())
+                            .build());
+        }
+
+        return clubDeletionDtos;
+    }
+}


### PR DESCRIPTION
동아리 삭제 화면에 필요한 API를 구현합니다.

- 동아리 삭제 목록 조회
- 동아리 삭제


**관련 이슈** 
> [FEAT] Web - 동아리 삭제 API 구현 https://github.com/In-lyeog-sa-mu-so/jjoin-server/issues/48

**고려해봐야할 부분**

> 앞서서 **동아리 조회를 할때 모두 ClubDeletion의 isDeleted가 True가 아닌 동아리만 조회하도록 변경해야합니다.**(해당 조건이 빠질 경우 삭제된 동아리도 조회가 됨).