### PR TITLE
✨ Feat : Web - 동아리 개설 신청 API 구현

### DIFF
--- a/src/main/java/org/dongguk/jjoin/controller/ManagerController.java
+++ b/src/main/java/org/dongguk/jjoin/controller/ManagerController.java
@@ -112,4 +112,10 @@ public class ManagerController {
         Long userId = 1L;
         return enrollmentService.createClubEnrollment(userId, clubEnrollmentRequestDto);
     }
+
+    @GetMapping("/enrollment/{enrollmentId}")
+    public ClubEnrollmentResponseDto readClubEnrollment(@PathVariable Long enrollmentId) {
+        Long userId = 1L;
+        return enrollmentService.readClubEnrollment(userId, enrollmentId);
+    }
 }

--- a/src/main/java/org/dongguk/jjoin/controller/ManagerController.java
+++ b/src/main/java/org/dongguk/jjoin/controller/ManagerController.java
@@ -4,11 +4,9 @@ import lombok.RequiredArgsConstructor;
 import org.dongguk.jjoin.dto.request.NoticeRequestDto;
 import org.dongguk.jjoin.dto.request.PlanRequestDto;
 import org.dongguk.jjoin.dto.request.PlanUpdateDto;
-import org.dongguk.jjoin.dto.response.ClubMainPageDtoByWeb;
+import org.dongguk.jjoin.dto.response.*;
 import org.dongguk.jjoin.dto.ClubMemberDtoByWeb;
-import org.dongguk.jjoin.dto.response.NoticeDto;
-import org.dongguk.jjoin.dto.response.NoticeListDto;
-import org.dongguk.jjoin.dto.response.PlanDto;
+import org.dongguk.jjoin.service.EnrollmentService;
 import org.dongguk.jjoin.service.ManagerService;
 import org.dongguk.jjoin.service.PlanService;
 import org.springframework.web.bind.annotation.*;
@@ -21,30 +19,31 @@ import java.util.List;
 public class ManagerController {
     private final ManagerService managerService;
     private final PlanService planService;
+    private final EnrollmentService enrollmentService;
 
     @PostMapping("/club/{clubId}/notice")
-    public void createNotice(@PathVariable Long clubId, @RequestBody NoticeRequestDto noticeRequestDto){
+    public void createNotice(@PathVariable Long clubId, @RequestBody NoticeRequestDto noticeRequestDto) {
         Long userId = 1L;   //  로그인 구현시 @GetUser 같은 어노테이션으로 대체해야함
         managerService.createNotice(userId, clubId, noticeRequestDto);
     }
 
     @GetMapping("/club/{clubId}/notice")
-    public List<NoticeListDto> showNoticeList(@PathVariable Long clubId, @RequestParam("page") Integer page, @RequestParam("size") Integer size){
+    public List<NoticeListDto> showNoticeList(@PathVariable Long clubId, @RequestParam("page") Integer page, @RequestParam("size") Integer size) {
         return managerService.showNoticeList(clubId, page, size);
     }
 
     @GetMapping("/club/{clubId}/notice/{noticeId}")
-    public NoticeDto readNotice(@PathVariable Long clubId, @PathVariable Long noticeId){
+    public NoticeDto readNotice(@PathVariable Long clubId, @PathVariable Long noticeId) {
         return managerService.readNotice(clubId, noticeId);
     }
 
     @PutMapping("/club/{clubId}/notice/{noticeId}")
-    public void updateNotice(@PathVariable Long clubId, @PathVariable Long noticeId, @RequestBody NoticeRequestDto noticeRequestDto){
+    public void updateNotice(@PathVariable Long clubId, @PathVariable Long noticeId, @RequestBody NoticeRequestDto noticeRequestDto) {
         managerService.updateNotice(clubId, noticeId, noticeRequestDto);
     }
 
     @DeleteMapping("/club/{clubId}/notice/{noticeId}")
-    public Boolean deleteNotice(@PathVariable Long clubId, @PathVariable Long noticeId){
+    public Boolean deleteNotice(@PathVariable Long clubId, @PathVariable Long noticeId) {
         managerService.deleteNotice(clubId, noticeId);
         return Boolean.TRUE;
     }
@@ -71,31 +70,37 @@ public class ManagerController {
 
     // 동아리 멤버 목록 조회
     @GetMapping("/club/{clubId}/member")
-    public List<ClubMemberDtoByWeb> readClubMembers(@PathVariable Long clubId, @RequestParam("page") Integer page, @RequestParam("size") Integer size){
+    public List<ClubMemberDtoByWeb> readClubMembers(@PathVariable Long clubId, @RequestParam("page") Integer page, @RequestParam("size") Integer size) {
         return managerService.readClubMembers(clubId, page, size);
     }
 
     // 동아리 멤버 권한 수정
     @PatchMapping("/club/{clubId}/member/{userId}/rank/{rankType}")
-    public void modifyMemberRole(@PathVariable Long clubId, @PathVariable Long userId, @PathVariable String rankType){
+    public void modifyMemberRole(@PathVariable Long clubId, @PathVariable Long userId, @PathVariable String rankType) {
         managerService.modifyMemberRole(clubId, userId, rankType);
     }
 
     // 동아리 멤버 퇴출
     @DeleteMapping("/club/{clubId}/member/{userId}")
-    public void deleteMember(@PathVariable Long clubId, @PathVariable List<Long> userId){
+    public void deleteMember(@PathVariable Long clubId, @PathVariable List<Long> userId) {
         managerService.deleteMember(clubId, userId);
     }
 
     // 동아리 기존 메인페이지 조회
     @GetMapping("/club/{clubId}/information")
-    public ClubMainPageDtoByWeb readClubMainPage(@PathVariable Long clubId){
+    public ClubMainPageDtoByWeb readClubMainPage(@PathVariable Long clubId) {
         return managerService.readClubMainPage(clubId);
     }
 
     // 동아리 메인페이지 수정
     @PutMapping("/club/{clubId}/information")
-    public void modifyClubMainPage(@PathVariable Long clubId, @RequestBody ClubMainPageDtoByWeb clubMainPageDtoByWeb){
+    public void modifyClubMainPage(@PathVariable Long clubId, @RequestBody ClubMainPageDtoByWeb clubMainPageDtoByWeb) {
         managerService.modifyClubMainPage(clubId, clubMainPageDtoByWeb);
+    }
+
+    @GetMapping("/enrollment")
+    public List<ClubEnrollmentDto> readClubEnrollmentList() {
+        Long userId = 1L;
+        return enrollmentService.readClubEnrollmentList(userId);
     }
 }

--- a/src/main/java/org/dongguk/jjoin/controller/ManagerController.java
+++ b/src/main/java/org/dongguk/jjoin/controller/ManagerController.java
@@ -1,6 +1,8 @@
 package org.dongguk.jjoin.controller;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.dongguk.jjoin.dto.request.ClubEnrollmentRequestDto;
 import org.dongguk.jjoin.dto.request.NoticeRequestDto;
 import org.dongguk.jjoin.dto.request.PlanRequestDto;
 import org.dongguk.jjoin.dto.request.PlanUpdateDto;
@@ -13,6 +15,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/manager")
@@ -102,5 +105,11 @@ public class ManagerController {
     public List<ClubEnrollmentDto> readClubEnrollmentList() {
         Long userId = 1L;
         return enrollmentService.readClubEnrollmentList(userId);
+    }
+
+    @PostMapping("/enrollment")
+    public Boolean createClubEnrollment(@RequestBody ClubEnrollmentRequestDto clubEnrollmentRequestDto) {
+        Long userId = 1L;
+        return enrollmentService.createClubEnrollment(userId, clubEnrollmentRequestDto);
     }
 }

--- a/src/main/java/org/dongguk/jjoin/domain/Club.java
+++ b/src/main/java/org/dongguk/jjoin/domain/Club.java
@@ -50,7 +50,7 @@ public class Club {
 
     //--------------------------------------------------------
 
-    @OneToMany(mappedBy = "club", fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "club", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     List<ClubTag> tags = new ArrayList<>();
 
     @OneToMany(mappedBy = "club", fetch = FetchType.LAZY)

--- a/src/main/java/org/dongguk/jjoin/domain/type/DependentType.java
+++ b/src/main/java/org/dongguk/jjoin/domain/type/DependentType.java
@@ -1,5 +1,25 @@
 package org.dongguk.jjoin.domain.type;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
 public enum DependentType {
-    MAJOR, CENTER
+    MAJOR("학과"), CENTER("중앙");
+
+    private final String description;
+
+    public String getDescription() {
+        return description;
+    }
+
+    @JsonCreator
+    public static DependentType from(String sub) {
+        for (DependentType dependentType : DependentType.values()) {
+            if (dependentType.description.equals(sub)) {
+                return dependentType;
+            }
+        }
+        throw new IllegalArgumentException();
+    }
 }

--- a/src/main/java/org/dongguk/jjoin/dto/request/ClubEnrollmentRequestDto.java
+++ b/src/main/java/org/dongguk/jjoin/dto/request/ClubEnrollmentRequestDto.java
@@ -1,0 +1,22 @@
+package org.dongguk.jjoin.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.dongguk.jjoin.domain.type.DependentType;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ClubEnrollmentRequestDto {
+    private String name;
+    private String introduction;
+    private DependentType dependentType;
+    private String clubImageOriginName;
+    private String clubImageUuidName;
+    private String backgroundImageOriginName;
+    private String backgroundImageUuidName;
+    private List<String> tags;
+}

--- a/src/main/java/org/dongguk/jjoin/dto/response/ClubEnrollmentDto.java
+++ b/src/main/java/org/dongguk/jjoin/dto/response/ClubEnrollmentDto.java
@@ -1,0 +1,25 @@
+package org.dongguk.jjoin.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.sql.Timestamp;
+import java.util.List;
+
+@Getter
+public class ClubEnrollmentDto {
+    private Long id;
+    private String clubName;
+    private String dependent;
+    private List<String> tags;
+    private Timestamp createdDate;
+
+    @Builder
+    public ClubEnrollmentDto(Long id, String clubName, String dependent, List<String> tags, Timestamp createdDate) {
+        this.id = id;
+        this.clubName = clubName;
+        this.dependent = dependent;
+        this.tags = tags;
+        this.createdDate = createdDate;
+    }
+}

--- a/src/main/java/org/dongguk/jjoin/dto/response/ClubEnrollmentResponseDto.java
+++ b/src/main/java/org/dongguk/jjoin/dto/response/ClubEnrollmentResponseDto.java
@@ -1,0 +1,33 @@
+package org.dongguk.jjoin.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.dongguk.jjoin.domain.type.DependentType;
+
+import java.util.List;
+
+@Getter
+public class ClubEnrollmentResponseDto {
+    private String name;
+    private String introduction;
+    private String dependentType;
+    private String clubImageOriginName;
+    private String clubImageUuidName;
+    private String backgroundImageOriginName;
+    private String backgroundImageUuidName;
+    private List<String> tags;
+
+    @Builder
+    public ClubEnrollmentResponseDto(String name, String introduction, String dependentType, String clubImageOriginName, String clubImageUuidName, String backgroundImageOriginName, String backgroundImageUuidName, List<String> tags) {
+        this.name = name;
+        this.introduction = introduction;
+        this.dependentType = dependentType;
+        this.clubImageOriginName = clubImageOriginName;
+        this.clubImageUuidName = clubImageUuidName;
+        this.backgroundImageOriginName = backgroundImageOriginName;
+        this.backgroundImageUuidName = backgroundImageUuidName;
+        this.tags = tags;
+    }
+}

--- a/src/main/java/org/dongguk/jjoin/repository/EnrollmentRepository.java
+++ b/src/main/java/org/dongguk/jjoin/repository/EnrollmentRepository.java
@@ -1,9 +1,16 @@
 package org.dongguk.jjoin.repository;
 
 import org.dongguk.jjoin.domain.Enrollment;
+import org.dongguk.jjoin.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
+    @Query(value = "SELECT e FROM Enrollment AS e WHERE e.club.leader = :user")
+    List<Enrollment> findByUser(@Param("user") User user);
 }

--- a/src/main/java/org/dongguk/jjoin/service/EnrollmentService.java
+++ b/src/main/java/org/dongguk/jjoin/service/EnrollmentService.java
@@ -7,6 +7,7 @@ import org.dongguk.jjoin.domain.type.ImageType;
 import org.dongguk.jjoin.dto.request.ClubEnrollmentRequestDto;
 import org.dongguk.jjoin.dto.request.EnrollmentUpdateDto;
 import org.dongguk.jjoin.dto.response.ClubEnrollmentDto;
+import org.dongguk.jjoin.dto.response.ClubEnrollmentResponseDto;
 import org.dongguk.jjoin.dto.response.EnrollmentDto;
 import org.dongguk.jjoin.repository.*;
 import org.springframework.stereotype.Service;
@@ -136,5 +137,27 @@ public class EnrollmentService {
                 .build());
 
         return Boolean.TRUE;
+    }
+
+    public ClubEnrollmentResponseDto readClubEnrollment(Long userId, Long enrollmentId) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new RuntimeException()); // 예외처리 수정 예정
+        Enrollment enrollments = enrollmentRepository.findById(enrollmentId).get();
+        Club club = enrollments.getClub();
+        Image clubImage = club.getClubImage();
+        Image backgroundImage = club.getBackgroundImage();
+
+        return ClubEnrollmentResponseDto.builder()
+                .name(club.getName())
+                .introduction(club.getIntroduction())
+                .dependentType(club.getDependent().getDescription())
+                .clubImageOriginName(clubImage.getOriginName())
+                .clubImageUuidName(clubImage.getUuidName())
+                .backgroundImageOriginName(backgroundImage.getOriginName())
+                .backgroundImageUuidName(backgroundImage.getUuidName())
+                .tags(club.getTags().stream().map(
+                        clubTag -> clubTag.getTag().getName())
+                        .collect(Collectors.toList())
+                )
+                .build();
     }
 }


### PR DESCRIPTION
동아리 개설신청 화면에 필요한 API를 구현합니다.

- 동아리 개설 신청서 목록 조회
- 동아리 개설 신청
- 동아리 개설 신청서 조회 


**관련 이슈** 
> [FEAT] Web - 동아리 개설 신청 API 구현 https://github.com/In-lyeog-sa-mu-so/jjoin-server/issues/49

**고려해봐야할 부분**

> 개설 거부를 당했을 시 관련 데이터를 모두 삭제할 수 있도록 개설 API를 수정하겠습니다.