### PR TITLE
✨ Feat: App - 동아리 가입신청서 API 구현

### DIFF
--- a/src/main/java/org/dongguk/jjoin/controller/ClubController.java
+++ b/src/main/java/org/dongguk/jjoin/controller/ClubController.java
@@ -64,4 +64,10 @@ public class ClubController {
         Long userId = 2L;
         return clubService.readClubRecommend(userId, userTagDtoList);
     }
+
+    // 동아리 가입신청서 양식 가져오기
+    @GetMapping("/{clubId}/applications")
+    public List<ApplicationQuestionDto> readClubApplication(@PathVariable Long clubId){
+        return clubService.readClubApplication(clubId);
+    }
 }

--- a/src/main/java/org/dongguk/jjoin/controller/ClubController.java
+++ b/src/main/java/org/dongguk/jjoin/controller/ClubController.java
@@ -68,7 +68,7 @@ public class ClubController {
 
     // 동아리 가입신청서 양식 가져오기
     @GetMapping("/{clubId}/applications")
-    public List<ApplicationQuestionDto> readClubApplication(@PathVariable Long clubId){
+    public ApplicationFormDto readClubApplication(@PathVariable Long clubId){
         return clubService.readClubApplication(clubId);
     }
 

--- a/src/main/java/org/dongguk/jjoin/controller/ClubController.java
+++ b/src/main/java/org/dongguk/jjoin/controller/ClubController.java
@@ -1,6 +1,7 @@
 package org.dongguk.jjoin.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.dongguk.jjoin.dto.request.ApplicationAnswerDto;
 import org.dongguk.jjoin.dto.response.*;
 import org.dongguk.jjoin.service.AlbumService;
 import org.dongguk.jjoin.service.ClubService;
@@ -69,5 +70,11 @@ public class ClubController {
     @GetMapping("/{clubId}/applications")
     public List<ApplicationQuestionDto> readClubApplication(@PathVariable Long clubId){
         return clubService.readClubApplication(clubId);
+    }
+
+    // 동아리 가입신청서 제출
+    @PostMapping("/{clubId}/applications")
+    public void submitClubApplication(@PathVariable Long clubId, @RequestBody List<ApplicationAnswerDto> applicationAnswerDtos) {
+        clubService.submitClubApplication(clubId, applicationAnswerDtos);
     }
 }

--- a/src/main/java/org/dongguk/jjoin/controller/ManagerController.java
+++ b/src/main/java/org/dongguk/jjoin/controller/ManagerController.java
@@ -146,6 +146,7 @@ public class ManagerController {
 
     // 동아리 가입 신청 거절
     @DeleteMapping("/club/{clubId}/application/{applicationId}")
-    public void refuseApplication(@PathVariable Long clubId, @PathVariable Long applicationId){
+    public void refuseApplication(@PathVariable Long clubId, @PathVariable Long applicationId) {
         managerService.refuseApplication(clubId, applicationId);
+    }
 }

--- a/src/main/java/org/dongguk/jjoin/dto/request/ApplicationAnswerDto.java
+++ b/src/main/java/org/dongguk/jjoin/dto/request/ApplicationAnswerDto.java
@@ -1,0 +1,9 @@
+package org.dongguk.jjoin.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class ApplicationAnswerDto {
+    private Long questionId;
+    private String answerContent;
+}

--- a/src/main/java/org/dongguk/jjoin/dto/response/ApplicationFormDto.java
+++ b/src/main/java/org/dongguk/jjoin/dto/response/ApplicationFormDto.java
@@ -1,0 +1,23 @@
+package org.dongguk.jjoin.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.sql.Timestamp;
+import java.util.List;
+
+@Getter
+public class ApplicationFormDto {
+    private String clubName;
+    private Timestamp startDate;
+    private Timestamp endDate;
+    private List<ApplicationQuestionDto> applicationQuestionDtos;
+
+    @Builder
+    public ApplicationFormDto(String clubName, Timestamp startDate, Timestamp endDate, List<ApplicationQuestionDto> applicationQuestionDtos) {
+        this.clubName = clubName;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.applicationQuestionDtos = applicationQuestionDtos;
+    }
+}

--- a/src/main/java/org/dongguk/jjoin/dto/response/ApplicationQuestionDto.java
+++ b/src/main/java/org/dongguk/jjoin/dto/response/ApplicationQuestionDto.java
@@ -1,0 +1,15 @@
+package org.dongguk.jjoin.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ApplicationQuestionDto {
+    private Long id;
+    private String content;
+    @Builder
+    public ApplicationQuestionDto(Long id, String content) {
+        this.id = id;
+        this.content = content;
+    }
+}

--- a/src/main/java/org/dongguk/jjoin/repository/ClubMemberRepository.java
+++ b/src/main/java/org/dongguk/jjoin/repository/ClubMemberRepository.java
@@ -24,8 +24,6 @@ public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
 
     List<ClubMember> findByClubId(Long clubId, Pageable pageable);
 
-    ClubMember findByUser(User user);
-
     @Query("SELECT cm FROM ClubMember AS cm WHERE cm.club.id = :clubId AND cm.user.id = :userId")
     Optional<ClubMember> findClubMemberByClubIdAndUserId(Long clubId, Long userId);
 

--- a/src/main/java/org/dongguk/jjoin/repository/QuestionRepository.java
+++ b/src/main/java/org/dongguk/jjoin/repository/QuestionRepository.java
@@ -5,8 +5,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface QuestionRepository extends JpaRepository<Application_question, Long> {
     List<Application_question> findAllByClubId(Long clubId);
+    Optional<Application_question> findById(Long id);
 }

--- a/src/main/java/org/dongguk/jjoin/service/ClubService.java
+++ b/src/main/java/org/dongguk/jjoin/service/ClubService.java
@@ -134,8 +134,9 @@ public class ClubService {
     }
 
     // 동아리 가입신청서 양식 가져오기
-    public List<ApplicationQuestionDto> readClubApplication(Long clubId) {
-        clubRepository.findById(clubId).orElseThrow(()-> new RuntimeException("No match Club"));
+    public ApplicationFormDto readClubApplication(Long clubId) {
+        Club club = clubRepository.findById(clubId).orElseThrow(()-> new RuntimeException("No match Club"));
+        Recruited_period recruitedPeriod = recruitedPeriodRepository.findByClub(club).orElseThrow(()-> new RuntimeException("Not Recuriting"));
         List<Application_question> applicationQuestions = questionRepository.findAllByClubId(clubId);
         if (applicationQuestions == null || applicationQuestions.isEmpty()) {
             throw new RuntimeException("A Club has No application");
@@ -148,7 +149,12 @@ public class ClubService {
                             .content(aQ.getContent())
                     .build());
         }
-        return applicationQuestionDtos;
+        return ApplicationFormDto.builder()
+                .clubName(club.getName())
+                .startDate(recruitedPeriod.getStartDate())
+                .endDate(recruitedPeriod.getEndDate())
+                .applicationQuestionDtos(applicationQuestionDtos)
+                .build();
     }
 
     // 동아리 가입신청서 제출

--- a/src/main/java/org/dongguk/jjoin/service/ClubService.java
+++ b/src/main/java/org/dongguk/jjoin/service/ClubService.java
@@ -13,7 +13,6 @@ import org.dongguk.jjoin.domain.*;
 import org.dongguk.jjoin.dto.request.UserTagDto;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -25,6 +24,7 @@ public class ClubService {
     private final ClubTagRepository clubTagRepository;
     private final UserRepository userRepository;
     private final RecruitedPeriodRepository recruitedPeriodRepository;
+    private final QuestionRepository questionRepository;
 
     // 동아리 게시글(공지, 홍보) 목록을 보여주는 API
     public List<NoticeListDtoByApp> showNoticeList(Long clubId, Integer page, Integer size){
@@ -128,5 +128,23 @@ public class ClubService {
         }
 
         return userClubDtoList;
+    }
+
+    // 동아리 가입신청서 양식 가져오기
+    public List<ApplicationQuestionDto> readClubApplication(Long clubId) {
+        clubRepository.findById(clubId).orElseThrow(()-> new RuntimeException("No match Club"));
+        List<Application_question> applicationQuestions = questionRepository.findAllByClubId(clubId);
+        if (applicationQuestions == null || applicationQuestions.isEmpty()) {
+            throw new RuntimeException("A Club has No application");
+        }
+
+        List<ApplicationQuestionDto> applicationQuestionDtos = new ArrayList<>();
+        for(Application_question aQ: applicationQuestions){
+            applicationQuestionDtos.add(ApplicationQuestionDto.builder()
+                            .id(aQ.getId())
+                            .content(aQ.getContent())
+                    .build());
+        }
+        return applicationQuestionDtos;
     }
 }


### PR DESCRIPTION
앱에서 동아리 가입하기 위해 신청서를 조회하고 작성하는 API를 구현합니다.

- [x] 동아리 가입 신청서 양식 가져오기
- [x] 동아리 가입 신청서 제출

- **관련 이슈**
> #54 

**고려해봐야할 부분**
> 동아리 가입 신청서 제출시에 User 정보를 저장하는 로직이 필요한데 로그인 구현 이후에 추가해야할 것 같습니다.