### PR TITLE
🐛 Fix: AdminController 관련 메소드 수정

### DIFF
--- a/src/main/java/org/dongguk/jjoin/controller/AdminController.java
+++ b/src/main/java/org/dongguk/jjoin/controller/AdminController.java
@@ -10,6 +10,7 @@ import org.dongguk.jjoin.service.ClubDeletionService;
 import org.dongguk.jjoin.service.EnrollmentService;
 import org.springframework.web.bind.annotation.*;
 
+import java.awt.print.Pageable;
 import java.util.List;
 
 @Slf4j
@@ -22,8 +23,8 @@ public class AdminController {
 
     // 관리자가 동아리 개설 신청서를 읽어오는 API
     @GetMapping("/enrollment")
-    public List<EnrollmentDto> readEnrollmentList() {
-        return enrollmentService.readEnrollments();
+    public List<EnrollmentDto> readEnrollmentList(@RequestParam Long page, @RequestParam Long size) {
+        return enrollmentService.readEnrollments(page, size);
     }
 
     // 관리자가 동아리 개설을 승인하는 API

--- a/src/main/java/org/dongguk/jjoin/controller/AdminController.java
+++ b/src/main/java/org/dongguk/jjoin/controller/AdminController.java
@@ -10,7 +10,6 @@ import org.dongguk.jjoin.service.ClubDeletionService;
 import org.dongguk.jjoin.service.EnrollmentService;
 import org.springframework.web.bind.annotation.*;
 
-import java.awt.print.Pageable;
 import java.util.List;
 
 @Slf4j
@@ -23,29 +22,31 @@ public class AdminController {
 
     // 관리자가 동아리 개설 신청서를 읽어오는 API
     @GetMapping("/enrollment")
-    public List<EnrollmentDto> readEnrollmentList(@RequestParam Long page, @RequestParam Long size) {
+    public List<EnrollmentDto> readEnrollments(@RequestParam Long page, @RequestParam Long size) {
         return enrollmentService.readEnrollments(page, size);
     }
 
     // 관리자가 동아리 개설을 승인하는 API
     @PutMapping("/enrollment")
-    public Boolean updateEnrollmentList(@RequestBody EnrollmentUpdateDto enrollmentUpdateDto) {
+    public Boolean updateEnrollments(@RequestBody EnrollmentUpdateDto enrollmentUpdateDto) {
         return enrollmentService.updateEnrollments(enrollmentUpdateDto);
     }
 
     // 관리자가 동아리 개설을 거부하는 API
     @DeleteMapping("/enrollment")
-    public Boolean deleteEnrollmentList(@RequestBody EnrollmentUpdateDto enrollmentUpdateDto) {
+    public Boolean deleteEnrollments(@RequestBody EnrollmentUpdateDto enrollmentUpdateDto) {
         return enrollmentService.deleteEnrollmentList(enrollmentUpdateDto);
     }
 
+    // 관리자가 동아리 삭제 신청 목록을 조회하는 API
     @GetMapping("/deletion")
-    public List<ClubDeletionDto> readClubDeletionList() {
-        return clubDeletionService.readClubDeletions();
+    public List<ClubDeletionDto> readClubDeletions(@RequestParam Long page, @RequestParam Long size) {
+        return clubDeletionService.readClubDeletions(page, size);
     }
 
+    // 관리자가 동아리 삭제 신청을 승인하는 API
     @PutMapping("/deletion")
     public Boolean updateClubDeletion(@RequestBody ClubDeletionUpdateDto clubDeletionUpdateDto) {
-        return clubDeletionService.updateClubDeltionList(clubDeletionUpdateDto);
+        return clubDeletionService.updateClubDeletions(clubDeletionUpdateDto);
     }
 }

--- a/src/main/java/org/dongguk/jjoin/controller/AdminController.java
+++ b/src/main/java/org/dongguk/jjoin/controller/AdminController.java
@@ -20,16 +20,19 @@ public class AdminController {
     private final EnrollmentService enrollmentService;
     private final ClubDeletionService clubDeletionService;
 
+    // 관리자가 동아리 개설 신청서를 읽어오는 API
     @GetMapping("/enrollment")
     public List<EnrollmentDto> readEnrollmentList() {
-        return enrollmentService.readEnrollmentList();
+        return enrollmentService.readEnrollments();
     }
 
+    // 관리자가 동아리 개설을 승인하는 API
     @PutMapping("/enrollment")
     public Boolean updateEnrollmentList(@RequestBody EnrollmentUpdateDto enrollmentUpdateDto) {
-        return enrollmentService.updateEnrollmentList(enrollmentUpdateDto);
+        return enrollmentService.updateEnrollments(enrollmentUpdateDto);
     }
 
+    // 관리자가 동아리 개설을 거부하는 API
     @DeleteMapping("/enrollment")
     public Boolean deleteEnrollmentList(@RequestBody EnrollmentUpdateDto enrollmentUpdateDto) {
         return enrollmentService.deleteEnrollmentList(enrollmentUpdateDto);
@@ -37,7 +40,7 @@ public class AdminController {
 
     @GetMapping("/deletion")
     public List<ClubDeletionDto> readClubDeletionList() {
-        return clubDeletionService.readClubDeletionList();
+        return clubDeletionService.readClubDeletions();
     }
 
     @PutMapping("/deletion")

--- a/src/main/java/org/dongguk/jjoin/controller/ClubController.java
+++ b/src/main/java/org/dongguk/jjoin/controller/ClubController.java
@@ -61,7 +61,7 @@ public class ClubController {
 
     @GetMapping("/recommends")
     public List<ClubRecommendDto> readClubRecommend(@RequestBody List<UserTagDto> userTagDtoList) {
-        Long userId = 2L;
+        Long userId = 1L;
         return clubService.readClubRecommend(userId, userTagDtoList);
     }
 }

--- a/src/main/java/org/dongguk/jjoin/controller/ManagerController.java
+++ b/src/main/java/org/dongguk/jjoin/controller/ManagerController.java
@@ -151,6 +151,7 @@ public class ManagerController {
 
     // 동아리 가입 신청 거절
     @DeleteMapping("/club/{clubId}/application/{applicationId}")
-    public void refuseApplication(@PathVariable Long clubId, @PathVariable Long applicationId){
+    public void refuseApplication(@PathVariable Long clubId, @PathVariable Long applicationId) {
         managerService.refuseApplication(clubId, applicationId);
+    }
 }

--- a/src/main/java/org/dongguk/jjoin/domain/Club.java
+++ b/src/main/java/org/dongguk/jjoin/domain/Club.java
@@ -40,11 +40,11 @@ public class Club {
     @Column(name = "created_date")
     private Timestamp createdDate;
 
-    @OneToOne
+    @OneToOne(cascade = CascadeType.REMOVE)
     @JoinColumn(name = "club_image")
     private Image clubImage;
 
-    @OneToOne
+    @OneToOne(cascade = CascadeType.REMOVE)
     @JoinColumn(name = "background_image")
     private Image backgroundImage;
 
@@ -82,6 +82,7 @@ public class Club {
         this.backgroundImage = backgroundImage;
     }
 
+    // 동아리 개설
     public void enrollClub() {
         this.createdDate = Timestamp.valueOf(LocalDateTime.now());
     }

--- a/src/main/java/org/dongguk/jjoin/domain/Club.java
+++ b/src/main/java/org/dongguk/jjoin/domain/Club.java
@@ -48,6 +48,9 @@ public class Club {
     @JoinColumn(name = "background_image")
     private Image backgroundImage;
 
+    @Column(name = "is_deleted", nullable = false)
+    private Boolean isDeleted;
+
     //--------------------------------------------------------
 
     @OneToMany(mappedBy = "club", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
@@ -91,5 +94,9 @@ public class Club {
         this.introduction = introduction;
         this.clubImage = clubImage;
         this.backgroundImage = backgroundImage;
+    }
+
+    public void deleteClub() {
+        this.isDeleted = Boolean.TRUE;
     }
 }

--- a/src/main/java/org/dongguk/jjoin/domain/ClubDeletion.java
+++ b/src/main/java/org/dongguk/jjoin/domain/ClubDeletion.java
@@ -6,6 +6,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @Setter
@@ -21,16 +24,16 @@ public class ClubDeletion {
     @JoinColumn(name = "club_id", nullable = false)
     private Club club;
 
-    @Column(name = "is_deleted", nullable = false)
-    private boolean isDeleted;
+    @Column(name = "created_date", nullable = false)
+    private Timestamp createdDate;
 
     @Builder
-    public ClubDeletion(Club club, boolean isDeleted) {
+    public ClubDeletion(Club club) {
         this.club = club;
-        this.isDeleted = false;
+        this.createdDate = Timestamp.valueOf(LocalDateTime.now());
     }
 
     public void deleteClub() {
-        isDeleted = true;
+        club.deleteClub();
     }
 }

--- a/src/main/java/org/dongguk/jjoin/domain/Enrollment.java
+++ b/src/main/java/org/dongguk/jjoin/domain/Enrollment.java
@@ -20,7 +20,7 @@ public class Enrollment {
     @Column(name = "id")
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     @JoinColumn(name = "club_id", nullable = false)
     private Club club;
 

--- a/src/main/java/org/dongguk/jjoin/dto/request/ClubDeletionUpdateDto.java
+++ b/src/main/java/org/dongguk/jjoin/dto/request/ClubDeletionUpdateDto.java
@@ -10,5 +10,5 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor
 public class ClubDeletionUpdateDto {
-    private List<Long> id;
+    private List<Long> ids;
 }

--- a/src/main/java/org/dongguk/jjoin/dto/request/EnrollmentUpdateDto.java
+++ b/src/main/java/org/dongguk/jjoin/dto/request/EnrollmentUpdateDto.java
@@ -10,5 +10,5 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor
 public class EnrollmentUpdateDto {
-    private List<Long> id;
+    private List<Long> ids;
 }

--- a/src/main/java/org/dongguk/jjoin/repository/ApplicationRepository.java
+++ b/src/main/java/org/dongguk/jjoin/repository/ApplicationRepository.java
@@ -10,7 +10,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface ApplicationRepository extends JpaRepository<ClubApplication, Long>{
+public interface ApplicationRepository extends JpaRepository<ClubApplication, Long> {
     @Query("SELECT ca FROM ClubApplication AS ca WHERE ca.club.id = :clubId ORDER BY ca.requestDate")
     List<ClubApplication> findApplicationList(Long clubId, Pageable pageable);
 

--- a/src/main/java/org/dongguk/jjoin/repository/ClubDeletionRepository.java
+++ b/src/main/java/org/dongguk/jjoin/repository/ClubDeletionRepository.java
@@ -1,6 +1,8 @@
 package org.dongguk.jjoin.repository;
 
 import org.dongguk.jjoin.domain.ClubDeletion;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -8,5 +10,4 @@ import java.util.List;
 
 @Repository
 public interface ClubDeletionRepository extends JpaRepository<ClubDeletion, Long> {
-    List<ClubDeletion> findByIsDeletedIsFalse();
 }

--- a/src/main/java/org/dongguk/jjoin/repository/ClubRepository.java
+++ b/src/main/java/org/dongguk/jjoin/repository/ClubRepository.java
@@ -21,5 +21,5 @@ public interface ClubRepository extends JpaRepository<Club, Long> {
     List<Club> findClubsByTagsAndKeyword(List<Tag> tagList, String keyword);
 
     // 검색 키워드로 클럽 검색
-    List<Club> findClubsByNameContainingOrIntroductionContainingIsDeletedIsFalseAndCreatedDateIsNotNull(String keyword, String keyword2);
+    List<Club> findClubsByNameContainingOrIntroductionContainingAndIsDeletedIsFalseAndCreatedDateIsNotNull(String keyword, String keyword2);
 }

--- a/src/main/java/org/dongguk/jjoin/repository/ClubRepository.java
+++ b/src/main/java/org/dongguk/jjoin/repository/ClubRepository.java
@@ -11,14 +11,15 @@ import java.util.Optional;
 
 @Repository
 public interface ClubRepository extends JpaRepository<Club, Long> {
-    @Query("SELECT c FROM Club AS c JOIN ClubTag AS ct ON ct.club = c WHERE ct.tag IN :tagList")
+    @Query("SELECT c FROM Club AS c JOIN ClubTag AS ct ON ct.club = c WHERE ct.tag IN :tagList AND c.isDeleted = FALSE " +
+            "AND c.createdDate != null")
     List<Club> findClubsByTags(List<Tag> tagList);
 
-    @Query("SELECT c FROM Club AS c JOIN ClubTag AS ct ON ct.club = c WHERE ct.tag IN :tagList AND (c.name LIKE %:keyword% OR c.introduction LIKE %:keyword%)")
+    @Query("SELECT c FROM Club AS c JOIN ClubTag AS ct ON ct.club = c WHERE ct.tag IN :tagList " +
+            "AND (c.name LIKE %:keyword% OR c.introduction LIKE %:keyword%) AND c.isDeleted = FALSE " +
+            "AND c.createdDate != null")
     List<Club> findClubsByTagsAndKeyword(List<Tag> tagList, String keyword);
 
     // 검색 키워드로 클럽 검색
-    List<Club> findClubsByNameContainingOrIntroductionContaining(String keyword, String keyword2);
-
-    Optional<Club> findById(Long clubId);
+    List<Club> findClubsByNameContainingOrIntroductionContainingIsDeletedIsFalseAndCreatedDateIsNotNull(String keyword, String keyword2);
 }

--- a/src/main/java/org/dongguk/jjoin/repository/EnrollmentRepository.java
+++ b/src/main/java/org/dongguk/jjoin/repository/EnrollmentRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.awt.print.Pageable;
 import java.util.List;
 
 @Repository

--- a/src/main/java/org/dongguk/jjoin/repository/EnrollmentRepository.java
+++ b/src/main/java/org/dongguk/jjoin/repository/EnrollmentRepository.java
@@ -3,6 +3,7 @@ package org.dongguk.jjoin.repository;
 import org.dongguk.jjoin.domain.Enrollment;
 import org.dongguk.jjoin.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -13,4 +14,8 @@ import java.util.List;
 public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
     @Query(value = "SELECT e FROM Enrollment AS e WHERE e.club.leader = :user")
     List<Enrollment> findByUser(@Param("user") User user);
+
+    @Modifying(clearAutomatically = true)
+    @Query(value = "DELETE FROM Enrollment AS e WHERE e.id in :ids")
+    void deleteByIds(@Param("ids") List<Long> ids);
 }

--- a/src/main/java/org/dongguk/jjoin/service/ClubDeletionService.java
+++ b/src/main/java/org/dongguk/jjoin/service/ClubDeletionService.java
@@ -21,7 +21,8 @@ import java.util.stream.Collectors;
 public class ClubDeletionService {
     private final ClubDeletionRepository clubDeletionRepository;
 
-    public List<ClubDeletionDto> readClubDeletionList() {
+    // 동아리 삭제 신청서 반환
+    public List<ClubDeletionDto> readClubDeletions() {
         List<ClubDeletion> clubDeletions = clubDeletionRepository.findByIsDeletedIsFalse();
         List<ClubDeletionDto> clubDeletionDtos = new ArrayList<>();
 
@@ -36,7 +37,6 @@ public class ClubDeletionService {
                             .createdDate(club.getCreatedDate())
                             .build());
         }
-
         return clubDeletionDtos;
     }
 

--- a/src/main/java/org/dongguk/jjoin/service/ClubDeletionService.java
+++ b/src/main/java/org/dongguk/jjoin/service/ClubDeletionService.java
@@ -7,6 +7,9 @@ import org.dongguk.jjoin.domain.ClubDeletion;
 import org.dongguk.jjoin.dto.request.ClubDeletionUpdateDto;
 import org.dongguk.jjoin.dto.response.ClubDeletionDto;
 import org.dongguk.jjoin.repository.ClubDeletionRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,31 +25,33 @@ public class ClubDeletionService {
     private final ClubDeletionRepository clubDeletionRepository;
 
     // 동아리 삭제 신청서 반환
-    public List<ClubDeletionDto> readClubDeletions() {
-        List<ClubDeletion> clubDeletions = clubDeletionRepository.findByIsDeletedIsFalse();
+    public List<ClubDeletionDto> readClubDeletions(Long page, Long size) {
+        PageRequest pageable = PageRequest.of(page.intValue(), size.intValue(), Sort.by(Sort.Direction.DESC, "createdDate"));
+        Page<ClubDeletion> clubDeletions = clubDeletionRepository.findAll(pageable);
         List<ClubDeletionDto> clubDeletionDtos = new ArrayList<>();
 
-        for (ClubDeletion clubDeletion : clubDeletions) {
+        for (ClubDeletion clubDeletion : clubDeletions.getContent()) {
             Club club = clubDeletion.getClub();
             clubDeletionDtos.add(ClubDeletionDto.builder()
-                            .id(clubDeletion.getId())
-                            .clubName(club.getName())
-                            .dependent(club.getDependent().toString())
-                            .tags(club.getTags().stream().map(clubTag -> clubTag.getTag().getName())
-                                    .collect(Collectors.toList()))
-                            .createdDate(club.getCreatedDate())
-                            .build());
+                    .id(clubDeletion.getId())
+                    .clubName(club.getName())
+                    .dependent(club.getDependent().toString())
+                    .tags(club.getTags().stream().map(clubTag -> clubTag.getTag().getName())
+                            .collect(Collectors.toList()))
+                    .createdDate(clubDeletion.getCreatedDate())
+                    .build());
         }
         return clubDeletionDtos;
     }
 
-    public Boolean updateClubDeltionList(ClubDeletionUpdateDto clubDeletionUpdateDto) {
-        List<Long> ids = clubDeletionUpdateDto.getId();
+    // 동아리 삭제 신청 승인
+    public Boolean updateClubDeletions(ClubDeletionUpdateDto clubDeletionUpdateDto) {
+        List<Long> ids = clubDeletionUpdateDto.getIds();
 
         for (Long id : ids) {
             clubDeletionRepository.findById(id).get().deleteClub();
+            clubDeletionRepository.deleteById(id);
         }
-
         return true;
     }
 }

--- a/src/main/java/org/dongguk/jjoin/service/EnrollmentService.java
+++ b/src/main/java/org/dongguk/jjoin/service/EnrollmentService.java
@@ -11,10 +11,14 @@ import org.dongguk.jjoin.dto.response.ClubEnrollmentResponseDto;
 import org.dongguk.jjoin.dto.response.EnrollmentDto;
 import org.dongguk.jjoin.repository.*;
 import org.dongguk.jjoin.util.FileUtil;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.awt.print.Pageable;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -35,22 +39,23 @@ public class EnrollmentService {
     private final FileUtil fileUtil;
 
     // 모든 개설 신청서 조회
-    public List<EnrollmentDto> readEnrollments() {
-        List<Enrollment> enrollments = enrollmentRepository.findAll();
+    public List<EnrollmentDto> readEnrollments(Long page, Long size) {
+        PageRequest pageable = PageRequest.of(page.intValue(), size.intValue(), Sort.by(Sort.Direction.DESC, "createdDate"));
+        Page<Enrollment> enrollments = enrollmentRepository.findAll(pageable);
         List<EnrollmentDto> enrollmentDtos = new ArrayList<>();
 
-        for (Enrollment enrollment : enrollments) {
+        for (Enrollment enrollment : enrollments.getContent()) {
             Club club = enrollment.getClub();
             List<String> tags = club.getTags().stream()
                     .map(clubTag -> clubTag.getTag().getName()).collect(Collectors.toList());
 
             enrollmentDtos.add(EnrollmentDto.builder()
-                            .id(enrollment.getId())
-                            .clubName(club.getName())
-                            .dependent(club.getDependent().toString())
-                            .tags(tags)
-                            .createdDate(Timestamp.valueOf(LocalDateTime.now()))
-                            .createdDate(enrollment.getCreatedDate())
+                    .id(enrollment.getId())
+                    .clubName(club.getName())
+                    .dependent(club.getDependent().toString())
+                    .tags(tags)
+                    .createdDate(Timestamp.valueOf(LocalDateTime.now()))
+                    .createdDate(enrollment.getCreatedDate())
                     .build());
         }
         return enrollmentDtos;
@@ -88,12 +93,12 @@ public class EnrollmentService {
         for (Enrollment enrollment : enrollments) {
             Club club = enrollment.getClub();
             clubEnrollmentDtos.add(ClubEnrollmentDto.builder()
-                            .id(enrollment.getId())
-                            .clubName(club.getName())
-                            .dependent(club.getDependent().toString())
-                            .tags(club.getTags().stream().map(clubTag -> clubTag.getTag().getName())
-                                    .collect(Collectors.toList()))
-                            .createdDate(enrollment.getCreatedDate())
+                    .id(enrollment.getId())
+                    .clubName(club.getName())
+                    .dependent(club.getDependent().toString())
+                    .tags(club.getTags().stream().map(clubTag -> clubTag.getTag().getName())
+                            .collect(Collectors.toList()))
+                    .createdDate(enrollment.getCreatedDate())
                     .build());
         }
 
@@ -165,7 +170,7 @@ public class EnrollmentService {
                 .backgroundImageOriginName(backgroundImage.getOriginName())
                 .backgroundImageUuidName(backgroundImage.getUuidName())
                 .tags(club.getTags().stream().map(
-                        clubTag -> clubTag.getTag().getName())
+                                clubTag -> clubTag.getTag().getName())
                         .collect(Collectors.toList())
                 )
                 .build();

--- a/src/main/java/org/dongguk/jjoin/service/SearchService.java
+++ b/src/main/java/org/dongguk/jjoin/service/SearchService.java
@@ -35,7 +35,7 @@ public class SearchService {
                 clubs = clubRepository.findClubsByTags(tagList);
             }
         } else if (!keyword.isEmpty()) { // 키워드 검색
-            clubs = clubRepository.findClubsByNameContainingOrIntroductionContainingIsDeletedIsFalseAndCreatedDateIsNotNull(keyword, keyword);
+            clubs = clubRepository.findClubsByNameContainingOrIntroductionContainingAndIsDeletedIsFalseAndCreatedDateIsNotNull(keyword, keyword);
         } else { // 검색 옵션 X
             clubs = clubRepository.findAll();
         }

--- a/src/main/java/org/dongguk/jjoin/service/SearchService.java
+++ b/src/main/java/org/dongguk/jjoin/service/SearchService.java
@@ -35,7 +35,7 @@ public class SearchService {
                 clubs = clubRepository.findClubsByTags(tagList);
             }
         } else if (!keyword.isEmpty()) { // 키워드 검색
-            clubs = clubRepository.findClubsByNameContainingOrIntroductionContaining(keyword, keyword);
+            clubs = clubRepository.findClubsByNameContainingOrIntroductionContainingIsDeletedIsFalseAndCreatedDateIsNotNull(keyword, keyword);
         } else { // 검색 옵션 X
             clubs = clubRepository.findAll();
         }


### PR DESCRIPTION
AdminController에서 다루는 동아리 개설 신청서 조회에 대한 페이징 처리 추가와 개설 신청 승인, 거부에서 발생할 수 있는 버그를 수정했습니다. 또한 동아리 삭제 신청서 조회에 대한 페이징 처리 추가와, 삭제 신청 승인에서 발생할 수 있는 버그를 수정했습니다. 또한 기존에 개설되지 않거나 삭제된 동아리에 대해서도 모든 동아리 조회가 가능했는데 이제부터는 삭제된 동아리와 개설되지 않은 동아리에 대해서는 조회가 불가능하도록 쿼리문을 수정하였습니다.

- 개설 신청서 조회 페이징 처리
- 개설 신청 승인 및 거부 버그 수정
- 삭제 신청서 조회 페이징 처리
- 삭제 신청 승인 버그 수정
- 개설되지 않거나 삭제된 동아리는 조회 시 제외


**관련 이슈** 
> [FIX] 쿼리문 수정 https://github.com/In-lyeog-sa-mu-so/jjoin-server/issues/57

**고려해봐야할 부분**

> 혹시라도 삭제된 동아리나 개설되지 않은 동아리 조회되는 버그가 발견된다면 발견하는 대로 수정하도록 하겠습니다. 또한 개설되지않고 삭제되지 않은 동아리에 대해서 조회하지 않도록 쿼리를 수정하여서 메소드명이 굉장히 길어지고 쿼리문도 복잡해졌는데 이 부분에 대해서 리팩토링을 어떻게 진행할지 고민하도록 해보겠습니다.