### PR TITLE
✨ Feat: Web - 관리자가 관리하는 동아리 조회 API 구현

### DIFF
--- a/src/main/java/org/dongguk/jjoin/controller/AdminController.java
+++ b/src/main/java/org/dongguk/jjoin/controller/AdminController.java
@@ -29,8 +29,7 @@ public class AdminController {
 
     @GetMapping("/enrollment/{enrollmentId}")
     public ClubEnrollmentResponseDto readEnrollment(@PathVariable Long enrollmentId){
-        Long userId = 1L;
-        return enrollmentService.readClubEnrollment(userId, enrollmentId);
+        return enrollmentService.readClubEnrollment(enrollmentId);
     }
 
     @PutMapping("/enrollment")

--- a/src/main/java/org/dongguk/jjoin/controller/AdminController.java
+++ b/src/main/java/org/dongguk/jjoin/controller/AdminController.java
@@ -5,6 +5,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.dongguk.jjoin.dto.request.ClubDeletionUpdateDto;
 import org.dongguk.jjoin.dto.request.EnrollmentUpdateDto;
 import org.dongguk.jjoin.dto.response.ClubDeletionDto;
+import org.dongguk.jjoin.dto.response.ClubEnrollmentDto;
+import org.dongguk.jjoin.dto.response.ClubEnrollmentResponseDto;
 import org.dongguk.jjoin.dto.response.EnrollmentDto;
 import org.dongguk.jjoin.service.ClubDeletionService;
 import org.dongguk.jjoin.service.EnrollmentService;
@@ -23,6 +25,12 @@ public class AdminController {
     @GetMapping("/enrollment")
     public List<EnrollmentDto> readEnrollmentList() {
         return enrollmentService.readEnrollmentList();
+    }
+
+    @GetMapping("/enrollment/{enrollmentId}")
+    public ClubEnrollmentResponseDto readEnrollment(@PathVariable Long enrollmentId){
+        Long userId = 1L;
+        return enrollmentService.readClubEnrollment(userId, enrollmentId);
     }
 
     @PutMapping("/enrollment")

--- a/src/main/java/org/dongguk/jjoin/controller/ManagerController.java
+++ b/src/main/java/org/dongguk/jjoin/controller/ManagerController.java
@@ -123,8 +123,7 @@ public class ManagerController {
 
     @GetMapping("/enrollment/{enrollmentId}")
     public ClubEnrollmentResponseDto readClubEnrollment(@PathVariable Long enrollmentId) {
-        Long userId = 1L;
-        return enrollmentService.readClubEnrollment(userId, enrollmentId);
+        return enrollmentService.readClubEnrollment(enrollmentId);
     }
   
     // 동아리 가입 신청서 질문 생성

--- a/src/main/java/org/dongguk/jjoin/controller/ManagerController.java
+++ b/src/main/java/org/dongguk/jjoin/controller/ManagerController.java
@@ -27,7 +27,7 @@ public class ManagerController {
 
     // 관리자가 관리하는 동아리 조회
     @GetMapping("/club")
-    public List<JoinedClubDto> showJoinedClubs(){
+    public List<ManagingClubDto> showJoinedClubs(){
         Long userId = 1L;
         return managerService.showJoinedClubs(userId);
     }

--- a/src/main/java/org/dongguk/jjoin/controller/ManagerController.java
+++ b/src/main/java/org/dongguk/jjoin/controller/ManagerController.java
@@ -25,6 +25,13 @@ public class ManagerController {
     private final PlanService planService;
     private final EnrollmentService enrollmentService;
 
+    // 관리자가 관리하는 동아리 조회
+    @GetMapping("/club")
+    public List<JoinedClubDto> showJoinedClubs(){
+        Long userId = 1L;
+        return managerService.showJoinedClubs(userId);
+    }
+
     @PostMapping("/club/{clubId}/notice")
     public void createNotice(@PathVariable Long clubId, @RequestBody NoticeRequestDto noticeRequestDto) {
         Long userId = 1L;   //  로그인 구현시 @GetUser 같은 어노테이션으로 대체해야함

--- a/src/main/java/org/dongguk/jjoin/dto/response/ClubEnrollmentResponseDto.java
+++ b/src/main/java/org/dongguk/jjoin/dto/response/ClubEnrollmentResponseDto.java
@@ -12,21 +12,17 @@ import java.util.List;
 public class ClubEnrollmentResponseDto {
     private String name;
     private String introduction;
-    private String dependentType;
-    private String clubImageOriginName;
+    private String dependent;
     private String clubImageUuidName;
-    private String backgroundImageOriginName;
     private String backgroundImageUuidName;
     private List<String> tags;
 
     @Builder
-    public ClubEnrollmentResponseDto(String name, String introduction, String dependentType, String clubImageOriginName, String clubImageUuidName, String backgroundImageOriginName, String backgroundImageUuidName, List<String> tags) {
+    public ClubEnrollmentResponseDto(String name, String introduction, String dependent, String clubImageUuidName, String backgroundImageUuidName, List<String> tags) {
         this.name = name;
         this.introduction = introduction;
-        this.dependentType = dependentType;
-        this.clubImageOriginName = clubImageOriginName;
+        this.dependent = dependent;
         this.clubImageUuidName = clubImageUuidName;
-        this.backgroundImageOriginName = backgroundImageOriginName;
         this.backgroundImageUuidName = backgroundImageUuidName;
         this.tags = tags;
     }

--- a/src/main/java/org/dongguk/jjoin/dto/response/JoinedClubDto.java
+++ b/src/main/java/org/dongguk/jjoin/dto/response/JoinedClubDto.java
@@ -1,0 +1,16 @@
+package org.dongguk.jjoin.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class JoinedClubDto {
+    private Long id;
+    private String name;
+
+    @Builder
+    public JoinedClubDto(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+}

--- a/src/main/java/org/dongguk/jjoin/dto/response/ManagingClubDto.java
+++ b/src/main/java/org/dongguk/jjoin/dto/response/ManagingClubDto.java
@@ -4,12 +4,12 @@ import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-public class JoinedClubDto {
+public class ManagingClubDto {
     private Long id;
     private String name;
 
     @Builder
-    public JoinedClubDto(Long id, String name) {
+    public ManagingClubDto(Long id, String name) {
         this.id = id;
         this.name = name;
     }

--- a/src/main/java/org/dongguk/jjoin/repository/ClubMemberRepository.java
+++ b/src/main/java/org/dongguk/jjoin/repository/ClubMemberRepository.java
@@ -30,4 +30,7 @@ public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("DELETE FROM ClubMember AS cm WHERE cm.club.id = :clubId AND cm.user.id IN :userIds")
     void deleteAllByClubIdAndUserId(Long clubId, List<Long> userIds);
+
+    @Query("SELECT cm.club FROM ClubMember AS cm WHERE cm.user.id = :userId AND cm.rankType != :rankType")
+    List<Club> findClubMemberByUserIdAndRankType(Long userId, RankType rankType);
 }

--- a/src/main/java/org/dongguk/jjoin/service/EnrollmentService.java
+++ b/src/main/java/org/dongguk/jjoin/service/EnrollmentService.java
@@ -139,9 +139,8 @@ public class EnrollmentService {
         return Boolean.TRUE;
     }
 
-    public ClubEnrollmentResponseDto readClubEnrollment(Long userId, Long enrollmentId) {
-        User user = userRepository.findById(userId).orElseThrow(() -> new RuntimeException()); // 예외처리 수정 예정
-        Enrollment enrollments = enrollmentRepository.findById(enrollmentId).get();
+    public ClubEnrollmentResponseDto readClubEnrollment(Long enrollmentId) {
+        Enrollment enrollments = enrollmentRepository.findById(enrollmentId).orElseThrow(() -> new RuntimeException("NO enrollment")); // 예외처리 수정 예정
         Club club = enrollments.getClub();
         Image clubImage = club.getClubImage();
         Image backgroundImage = club.getBackgroundImage();

--- a/src/main/java/org/dongguk/jjoin/service/EnrollmentService.java
+++ b/src/main/java/org/dongguk/jjoin/service/EnrollmentService.java
@@ -149,10 +149,8 @@ public class EnrollmentService {
         return ClubEnrollmentResponseDto.builder()
                 .name(club.getName())
                 .introduction(club.getIntroduction())
-                .dependentType(club.getDependent().getDescription())
-                .clubImageOriginName(clubImage.getOriginName())
+                .dependent(club.getDependent().getDescription())
                 .clubImageUuidName(clubImage.getUuidName())
-                .backgroundImageOriginName(backgroundImage.getOriginName())
                 .backgroundImageUuidName(backgroundImage.getUuidName())
                 .tags(club.getTags().stream().map(
                         clubTag -> clubTag.getTag().getName())

--- a/src/main/java/org/dongguk/jjoin/service/ManagerService.java
+++ b/src/main/java/org/dongguk/jjoin/service/ManagerService.java
@@ -33,6 +33,19 @@ public class ManagerService {
     private final ApplicationRepository applicationRepository;
     private final AnswerRepository answerRepository;
 
+    // 관리자가 관리하는 동아리 조회
+    public List<JoinedClubDto> showJoinedClubs(Long userId){
+        List<Club> clubs = clubMemberRepository.findClubMemberByUserIdAndRankType(userId, RankType.MEMBER);
+        List<JoinedClubDto> joinedClubDtos = new ArrayList<>();
+        for (Club club: clubs){
+            joinedClubDtos.add(JoinedClubDto.builder()
+                    .id(club.getId())
+                    .name(club.getName())
+                    .build());
+        }
+        return joinedClubDtos;
+    }
+
     public List<NoticeListDto> showNoticeList(Long clubId, Integer page, Integer size){
         Club club = clubRepository.findById(clubId).orElseThrow(()-> new RuntimeException("no match clubId"));
         List<Notice> notices = Optional.ofNullable(club.getNotices()).orElseThrow(()-> new RuntimeException("Notice Not found!"));

--- a/src/main/java/org/dongguk/jjoin/service/ManagerService.java
+++ b/src/main/java/org/dongguk/jjoin/service/ManagerService.java
@@ -34,16 +34,16 @@ public class ManagerService {
     private final AnswerRepository answerRepository;
 
     // 관리자가 관리하는 동아리 조회
-    public List<JoinedClubDto> showJoinedClubs(Long userId){
+    public List<ManagingClubDto> showJoinedClubs(Long userId){
         List<Club> clubs = clubMemberRepository.findClubMemberByUserIdAndRankType(userId, RankType.MEMBER);
-        List<JoinedClubDto> joinedClubDtos = new ArrayList<>();
+        List<ManagingClubDto> managingClubDtos = new ArrayList<>();
         for (Club club: clubs){
-            joinedClubDtos.add(JoinedClubDto.builder()
+            managingClubDtos.add(ManagingClubDto.builder()
                     .id(club.getId())
                     .name(club.getName())
                     .build());
         }
-        return joinedClubDtos;
+        return managingClubDtos;
     }
 
     public List<NoticeListDto> showNoticeList(Long clubId, Integer page, Integer size){


### PR DESCRIPTION
관리자 웹에서 관리자가 관리하는 동아리들을 보여주는 API를 구현합니다.
\+ 추가로 admin측 개설신청 상세보기도 구현하였습니다.

- 관리하는 동아리 조회 API 구현
- Admin측 개설신청 상세조회 API 구현


**관련 이슈**
> #61 

**고려해봐야할 부분**
> 로그인 구현시 현재 로그인 되어 있는 유저 id를 바탕으로 clubd을 조회해오기 때문에 그 부분에 대한 수정이 필요합니다.