### PR TITLE
🐛 Fix: 마이페이지 및 동아리 조회, 개설신청서 CRUD 수정

### DIFF
--- a/src/main/java/org/dongguk/jjoin/controller/ManagerController.java
+++ b/src/main/java/org/dongguk/jjoin/controller/ManagerController.java
@@ -138,6 +138,7 @@ public class ManagerController {
         return enrollmentService.createClubEnrollment(userId, data, clubImageFile, backgroundImageFile);
     }
 
+    // 동아리 개설 신청서 조회 API
     @GetMapping("/enrollment/{enrollmentId}")
     public ClubEnrollmentResponseDto readClubEnrollment(@PathVariable Long enrollmentId) {
         return enrollmentService.readClubEnrollment(enrollmentId);

--- a/src/main/java/org/dongguk/jjoin/controller/ManagerController.java
+++ b/src/main/java/org/dongguk/jjoin/controller/ManagerController.java
@@ -129,6 +129,7 @@ public class ManagerController {
         return enrollmentService.readClubEnrollments(userId);
     }
 
+    // 동아리 개설 API
     @PostMapping("/enrollment")
     public Boolean createClubEnrollment(@RequestPart ClubEnrollmentRequestDto data,
                                         @RequestPart MultipartFile clubImageFile,

--- a/src/main/java/org/dongguk/jjoin/controller/ManagerController.java
+++ b/src/main/java/org/dongguk/jjoin/controller/ManagerController.java
@@ -122,10 +122,11 @@ public class ManagerController {
         managerService.modifyClubMainPage(clubId, data, clubImageFile, backgroundImageFile);
     }
 
+    // 동아리 개설 신청서 목록 조회 API
     @GetMapping("/enrollment")
-    public List<ClubEnrollmentDto> readClubEnrollmentList() {
+    public List<ClubEnrollmentDto> readClubEnrollments() {
         Long userId = 1L;
-        return enrollmentService.readClubEnrollmentList(userId);
+        return enrollmentService.readClubEnrollments(userId);
     }
 
     @PostMapping("/enrollment")

--- a/src/main/java/org/dongguk/jjoin/controller/UserController.java
+++ b/src/main/java/org/dongguk/jjoin/controller/UserController.java
@@ -25,12 +25,14 @@ public class UserController {
     private final ScheduleService scheduleService;
     private final ClubService clubService;
 
+    // 홈화면에서의 가입한 동아리 조회 API
     @GetMapping("/clubs")
     public List<ClubCardDto> readUserClubs() {
         Long userId = 1L;
         return userService.readUserClubs(userId);
     }
 
+    // 홈화면에서의 사용자의 스케줄 조회 API
     @GetMapping("/schedules")
     public List<ScheduleDayDto> readUserSchedules() {
         Long userId = 1L;
@@ -54,8 +56,9 @@ public class UserController {
         return userService.deleteUser(userId);
     }
 
+    // 마이페이지에서의 사용자 동아리 조회 API
     @GetMapping("/{userId}/clubs")
     public List<UserClubDto> readUserClubs(@PathVariable Long userId) {
-        return clubService.readUserClubList(userId);
+        return clubService.readUserClubs(userId);
     }
 }

--- a/src/main/java/org/dongguk/jjoin/controller/UserController.java
+++ b/src/main/java/org/dongguk/jjoin/controller/UserController.java
@@ -40,17 +40,20 @@ public class UserController {
         return scheduleService.readDaySchedules(userId, targetDate);
     }
 
+    // 사용자 조회 API
     @GetMapping("/{userId}")
     public UserProfileDto readUserProfile(@PathVariable Long userId) {
         return userService.readUserProfile(userId);
     }
 
+    // 사용자 프로필 변경 API
     @PutMapping("/{userId}")
     public Boolean updateUserProfile(@PathVariable Long userId, @RequestPart UserProfileUpdateDto data,
                                      @RequestPart MultipartFile userProfileImageFile) {
         return userService.updateUserProfile(userId, data, userProfileImageFile);
     }
 
+    // 회원 탈퇴 API
     @DeleteMapping("/{userId}")
     public Boolean deleteUser(@PathVariable Long userId) {
         return userService.deleteUser(userId);

--- a/src/main/java/org/dongguk/jjoin/dto/request/ClubEnrollmentRequestDto.java
+++ b/src/main/java/org/dongguk/jjoin/dto/request/ClubEnrollmentRequestDto.java
@@ -13,6 +13,6 @@ import java.util.List;
 public class ClubEnrollmentRequestDto {
     private String name;
     private String introduction;
-    private DependentType dependentType;
+    private DependentType dependent;
     private List<String> tags;
 }

--- a/src/main/java/org/dongguk/jjoin/dto/response/ClubCardDto.java
+++ b/src/main/java/org/dongguk/jjoin/dto/response/ClubCardDto.java
@@ -5,22 +5,22 @@ import lombok.Getter;
 
 @Getter
 public class ClubCardDto {
-    private Long clubId;
-    private String clubName;
+    private Long id;
+    private String name;
     private String introduction;
     private String leaderName;
-    private Long userNumber;
+    private Long numberOfMembers;
     private String dependent;
     private String profileImageUuid;
     private String newestNotice;
 
     @Builder
-    public ClubCardDto(Long clubId, String clubName, String introduction, String leaderName, Long userNumber, String dependent, String profileImageUuid, String newestNotice) {
-        this.clubId = clubId;
-        this.clubName = clubName;
+    public ClubCardDto(Long id, String name, String introduction, String leaderName, Long numberOfMembers, String dependent, String profileImageUuid, String newestNotice) {
+        this.id = id;
+        this.name = name;
         this.introduction = introduction;
         this.leaderName = leaderName;
-        this.userNumber = userNumber;
+        this.numberOfMembers = numberOfMembers;
         this.dependent = dependent;
         this.profileImageUuid = profileImageUuid;
         this.newestNotice = newestNotice;

--- a/src/main/java/org/dongguk/jjoin/dto/response/ClubEnrollmentDto.java
+++ b/src/main/java/org/dongguk/jjoin/dto/response/ClubEnrollmentDto.java
@@ -9,15 +9,15 @@ import java.util.List;
 @Getter
 public class ClubEnrollmentDto {
     private Long id;
-    private String clubName;
+    private String name;
     private String dependent;
     private List<String> tags;
     private Timestamp createdDate;
 
     @Builder
-    public ClubEnrollmentDto(Long id, String clubName, String dependent, List<String> tags, Timestamp createdDate) {
+    public ClubEnrollmentDto(Long id, String name, String dependent, List<String> tags, Timestamp createdDate) {
         this.id = id;
-        this.clubName = clubName;
+        this.name = name;
         this.dependent = dependent;
         this.tags = tags;
         this.createdDate = createdDate;

--- a/src/main/java/org/dongguk/jjoin/dto/response/ClubEnrollmentResponseDto.java
+++ b/src/main/java/org/dongguk/jjoin/dto/response/ClubEnrollmentResponseDto.java
@@ -1,10 +1,7 @@
 package org.dongguk.jjoin.dto.response;
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import org.dongguk.jjoin.domain.type.DependentType;
 
 import java.util.List;
 
@@ -13,17 +10,17 @@ public class ClubEnrollmentResponseDto {
     private String name;
     private String introduction;
     private String dependent;
-    private String clubImageUuidName;
-    private String backgroundImageUuidName;
+    private String clubImageUuid;
+    private String backgroundImageUuid;
     private List<String> tags;
 
     @Builder
-    public ClubEnrollmentResponseDto(String name, String introduction, String dependent, String clubImageUuidName, String backgroundImageUuidName, List<String> tags) {
+    public ClubEnrollmentResponseDto(String name, String introduction, String dependent, String clubImageUuid, String backgroundImageUuid, List<String> tags) {
         this.name = name;
         this.introduction = introduction;
         this.dependent = dependent;
-        this.clubImageUuidName = clubImageUuidName;
-        this.backgroundImageUuidName = backgroundImageUuidName;
+        this.clubImageUuid = clubImageUuid;
+        this.backgroundImageUuid = backgroundImageUuid;
         this.tags = tags;
     }
 }

--- a/src/main/java/org/dongguk/jjoin/dto/response/ClubScheduleDetailDto.java
+++ b/src/main/java/org/dongguk/jjoin/dto/response/ClubScheduleDetailDto.java
@@ -8,7 +8,6 @@ import java.sql.Timestamp;
 @Getter
 public class ClubScheduleDetailDto {
     private Long id;
-    private String name;
     private String title;
     private String content;
     private Timestamp startDate;
@@ -16,11 +15,12 @@ public class ClubScheduleDetailDto {
     private Timestamp createdDate;
     private Timestamp updatedDate;
     private Boolean isAgreed;
+    private Long numberOfAgree;
+    private Long numberOfDisagree;
 
     @Builder
-    public ClubScheduleDetailDto(Long id, String name, String title, String content, Timestamp startDate, Timestamp endDate, Timestamp createdDate, Timestamp updatedDate, Boolean isAgreed) {
+    public ClubScheduleDetailDto(Long id, String title, String content, Timestamp startDate, Timestamp endDate, Timestamp createdDate, Timestamp updatedDate, Boolean isAgreed, Long numberOfAgree, Long numberOfDisagree) {
         this.id = id;
-        this.name = name;
         this.title = title;
         this.content = content;
         this.startDate = startDate;
@@ -28,5 +28,7 @@ public class ClubScheduleDetailDto {
         this.createdDate = createdDate;
         this.updatedDate = updatedDate;
         this.isAgreed = isAgreed;
+        this.numberOfAgree = numberOfAgree;
+        this.numberOfDisagree = numberOfDisagree;
     }
 }

--- a/src/main/java/org/dongguk/jjoin/dto/response/ScheduleDayDto.java
+++ b/src/main/java/org/dongguk/jjoin/dto/response/ScheduleDayDto.java
@@ -8,6 +8,7 @@ import java.sql.Timestamp;
 @Getter
 public class ScheduleDayDto {
     private Long id;
+    private Long clubId;
     private String name;
     private Timestamp startDate;
     private Timestamp endDate;
@@ -16,8 +17,9 @@ public class ScheduleDayDto {
     private Boolean isAgreed;
 
     @Builder
-    public ScheduleDayDto(Long id, String name, Timestamp startDate, Timestamp endDate, String title, String content, Boolean isAgreed) {
+    public ScheduleDayDto(Long id, Long clubId, String name, Timestamp startDate, Timestamp endDate, String title, String content, Boolean isAgreed) {
         this.id = id;
+        this.clubId = clubId;
         this.name = name;
         this.startDate = startDate;
         this.endDate = endDate;

--- a/src/main/java/org/dongguk/jjoin/dto/response/UserClubDto.java
+++ b/src/main/java/org/dongguk/jjoin/dto/response/UserClubDto.java
@@ -5,14 +5,14 @@ import lombok.Getter;
 
 @Getter
 public class UserClubDto {
-    private Long clubId;
-    private String clubImage;
-    private String clubName;
+    private Long id;
+    private String clubImageUuid;
+    private String name;
 
     @Builder
-    public UserClubDto(Long clubId, String clubImage, String clubName) {
-        this.clubId = clubId;
-        this.clubImage = clubImage;
-        this.clubName = clubName;
+    public UserClubDto(Long id, String clubImageUuid, String name) {
+        this.id = id;
+        this.clubImageUuid = clubImageUuid;
+        this.name = name;
     }
 }

--- a/src/main/java/org/dongguk/jjoin/dto/response/UserProfileDto.java
+++ b/src/main/java/org/dongguk/jjoin/dto/response/UserProfileDto.java
@@ -5,15 +5,15 @@ import lombok.Getter;
 
 @Getter
 public class UserProfileDto {
-    private Long userId;
+    private Long id;
     private String profileImageUuid;
     private String name;
     private String major;
     private String introduction;
 
     @Builder
-    public UserProfileDto(Long userId, String profileImageUuid, String name, String major, String introduction) {
-        this.userId = userId;
+    public UserProfileDto(Long id, String profileImageUuid, String name, String major, String introduction) {
+        this.id = id;
         this.profileImageUuid = profileImageUuid;
         this.name = name;
         this.major = major;

--- a/src/main/java/org/dongguk/jjoin/repository/ScheduleRepository.java
+++ b/src/main/java/org/dongguk/jjoin/repository/ScheduleRepository.java
@@ -24,4 +24,6 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     @Query(value = "SELECT s FROM Schedule AS s INNER JOIN Plan AS p ON s.plan = p " +
             "WHERE s.user = :user AND s.isAgreed = null AND p.startDate >= :targetDate")
     List<Schedule> findUnplansByDate(@Param("user") User user, @Param("targetDate") Timestamp targetDate);
+
+    Long countByPlanAndIsAgreed(Plan plan, Boolean isAgreed);
 }

--- a/src/main/java/org/dongguk/jjoin/service/ClubService.java
+++ b/src/main/java/org/dongguk/jjoin/service/ClubService.java
@@ -116,19 +116,18 @@ public class ClubService {
                 .build();
     }
 
-    public List<UserClubDto> readUserClubList(Long userId) {
+    public List<UserClubDto> readUserClubs(Long userId) {
         User user = userRepository.findById(userId).get();
         List<Club> clubList = clubMemberRepository.findUserClubsByUser(user);
         List<UserClubDto> userClubDtoList = new ArrayList<>();
 
         for (Club club : clubList) {
             userClubDtoList.add(UserClubDto.builder()
-                    .clubId(club.getId())
-                    .clubImage(club.getClubImage().getUuidName())
-                    .clubName(club.getName())
+                    .id(club.getId())
+                    .clubImageUuid(club.getClubImage().getUuidName())
+                    .name(club.getName())
                     .build());
         }
-
         return userClubDtoList;
     }
 

--- a/src/main/java/org/dongguk/jjoin/service/EnrollmentService.java
+++ b/src/main/java/org/dongguk/jjoin/service/EnrollmentService.java
@@ -140,19 +140,18 @@ public class EnrollmentService {
                 .name(data.getName())
                 .introduction(data.getIntroduction())
                 .leader(user)
-                .dependent(data.getDependentType())
+                .dependent(data.getDependent())
                 .clubImage(clubImage)
-                .backgroundImage(backgroundImage).build());
+                .backgroundImage(backgroundImage)
+                .build());
 
-        List<String> tagNames = data.getTags();
-        List<Tag> tags = tagRepository.findByNames(tagNames);
+        List<Tag> tags = tagRepository.findByNames(data.getTags());
         for (Tag tag : tags) {
             clubTagRepository.save(ClubTag.builder()
                     .club(club)
                     .tag(tag)
                     .build());
         }
-
         enrollmentRepository.save(Enrollment.builder()
                 .club(club)
                 .build());

--- a/src/main/java/org/dongguk/jjoin/service/EnrollmentService.java
+++ b/src/main/java/org/dongguk/jjoin/service/EnrollmentService.java
@@ -19,7 +19,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.awt.print.Pageable;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -92,7 +91,7 @@ public class EnrollmentService {
         return Boolean.TRUE;
     }
 
-    public List<ClubEnrollmentDto> readClubEnrollmentList(Long userId) {
+    public List<ClubEnrollmentDto> readClubEnrollments(Long userId) {
         User user = userRepository.findById(userId).orElseThrow(() -> new RuntimeException()); // 예외처리 수정 예정
         List<Enrollment> enrollments = enrollmentRepository.findByUser(user);
         List<ClubEnrollmentDto> clubEnrollmentDtos = new ArrayList<>();
@@ -101,7 +100,7 @@ public class EnrollmentService {
             Club club = enrollment.getClub();
             clubEnrollmentDtos.add(ClubEnrollmentDto.builder()
                     .id(enrollment.getId())
-                    .clubName(club.getName())
+                    .name(club.getName())
                     .dependent(club.getDependent().toString())
                     .tags(club.getTags().stream().map(clubTag -> clubTag.getTag().getName())
                             .collect(Collectors.toList()))

--- a/src/main/java/org/dongguk/jjoin/service/EnrollmentService.java
+++ b/src/main/java/org/dongguk/jjoin/service/EnrollmentService.java
@@ -91,6 +91,7 @@ public class EnrollmentService {
         return Boolean.TRUE;
     }
 
+    // 동아리 개설 신청서 목록 반환
     public List<ClubEnrollmentDto> readClubEnrollments(Long userId) {
         User user = userRepository.findById(userId).orElseThrow(() -> new RuntimeException()); // 예외처리 수정 예정
         List<Enrollment> enrollments = enrollmentRepository.findByUser(user);
@@ -111,6 +112,7 @@ public class EnrollmentService {
         return clubEnrollmentDtos;
     }
 
+    // 동아리 개설 신청
     public Boolean createClubEnrollment(Long userId, ClubEnrollmentRequestDto data, MultipartFile clubImageFile, MultipartFile backgroundImageFile) {
         User user = userRepository.findById(userId).orElseThrow(() -> new RuntimeException()); // 예외처리 수정 예정
 
@@ -159,6 +161,7 @@ public class EnrollmentService {
         return Boolean.TRUE;
     }
 
+    // 동아리 개설 신청서 상세 반환
     public ClubEnrollmentResponseDto readClubEnrollment(Long enrollmentId) {
         Enrollment enrollments = enrollmentRepository.findById(enrollmentId).orElseThrow(() -> new RuntimeException("NO enrollment")); // 예외처리 수정 예정
         Club club = enrollments.getClub();
@@ -169,12 +172,11 @@ public class EnrollmentService {
                 .name(club.getName())
                 .introduction(club.getIntroduction())
                 .dependent(club.getDependent().getDescription())
-                .clubImageUuidName(clubImage.getUuidName())
-                .backgroundImageUuidName(backgroundImage.getUuidName())
+                .clubImageUuid(clubImage.getUuidName())
+                .backgroundImageUuid(backgroundImage.getUuidName())
                 .tags(club.getTags().stream().map(
                                 clubTag -> clubTag.getTag().getName())
-                        .collect(Collectors.toList())
-                )
+                        .collect(Collectors.toList()))
                 .build();
     }
 }

--- a/src/main/java/org/dongguk/jjoin/service/ScheduleService.java
+++ b/src/main/java/org/dongguk/jjoin/service/ScheduleService.java
@@ -37,6 +37,7 @@ public class ScheduleService {
     private final PlanRepository planRepository;
     private final DateUtil dateUtil;
 
+    // 특정 날짜에 해당하는 일정 목록 반환
     public List<ScheduleDayDto> readDaySchedules(Long userId, String targetDate) {
         User user = userRepository.findById(userId).orElseThrow(() -> new RuntimeException()); // 예외처리 수정 예정
         Timestamp date = dateUtil.stringToTimestamp(targetDate);
@@ -48,11 +49,11 @@ public class ScheduleService {
             Plan plan = schedule.getPlan();
             scheduleDayDtos.add(ScheduleDayDto.builder()
                     .id(schedule.getId())
+                    .clubId(plan.getClub().getId())
                     .name(plan.getClub().getName())
                     .startDate(plan.getStartDate())
                     .endDate(plan.getEndDate())
                     .title(plan.getTitle())
-
                     .content(plan.getContent())
                     .isAgreed(schedule.getIsAgreed())
                     .build());
@@ -73,6 +74,7 @@ public class ScheduleService {
                 Plan plan = schedule.getPlan();
                 scheduleDayDtos.add(ScheduleDayDto.builder()
                         .id(schedule.getId())
+                        .clubId(plan.getClub().getId())
                         .name(plan.getClub().getName())
                         .startDate(plan.getStartDate())
                         .endDate(plan.getEndDate())
@@ -89,6 +91,7 @@ public class ScheduleService {
         return scheduleDaysDtos;
     }
 
+    // 개인 일정 동의 및 거부
     public Boolean updateSchedule(Long scheduleId, ScheduleDecideDto scheduleDecideDto) {
         Schedule schedule = scheduleRepository.findById(scheduleId).get();
         schedule.scheduleDecidedBy(scheduleDecideDto.getIsAgreed());
@@ -118,13 +121,13 @@ public class ScheduleService {
         return clubScheduleDtos;
     }
 
+    // 일정 상세 조회
     public ClubScheduleDetailDto readClubScheduleDetail(Long clubId, Long scheduleId) {
         Schedule schedule = scheduleRepository.findById(scheduleId).get();
         Plan plan = schedule.getPlan();
 
         return ClubScheduleDetailDto.builder()
                 .id(schedule.getId())
-                .name(clubRepository.findById(clubId).get().getName())
                 .title(plan.getTitle())
                 .content(plan.getContent())
                 .startDate(plan.getStartDate())
@@ -132,6 +135,8 @@ public class ScheduleService {
                 .createdDate(plan.getCreatedDate())
                 .updatedDate(plan.getUpdatedDate())
                 .isAgreed(schedule.getIsAgreed())
+                .numberOfAgree(scheduleRepository.countByPlanAndIsAgreed(plan, true))
+                .numberOfDisagree(scheduleRepository.countByPlanAndIsAgreed(plan, false))
                 .build();
     }
 }

--- a/src/main/java/org/dongguk/jjoin/service/UserService.java
+++ b/src/main/java/org/dongguk/jjoin/service/UserService.java
@@ -53,7 +53,7 @@ public class UserService {
         User user = userRepository.findById(userId).get();
 
         return UserProfileDto.builder()
-                .userId(user.getId())
+                .id(user.getId())
                 .profileImageUuid(user.getProfileImage().getUuidName())
                 .name(user.getName())
                 .major(user.getMajor().toString())

--- a/src/main/java/org/dongguk/jjoin/service/UserService.java
+++ b/src/main/java/org/dongguk/jjoin/service/UserService.java
@@ -29,6 +29,7 @@ public class UserService {
     private final ImageRepository imageRepository;
     private final FileUtil fileUtil;
 
+    // 사용자가 가입한 동아리 반환
     public List<ClubCardDto> readUserClubs(Long userId) {
         User user = userRepository.findById(userId).orElseThrow(() -> new RuntimeException()); // 예외처리 수정 예정
         List<Club> clubs = clubMemberRepository.findUserClubsByUser(user);

--- a/src/main/java/org/dongguk/jjoin/service/UserService.java
+++ b/src/main/java/org/dongguk/jjoin/service/UserService.java
@@ -77,12 +77,11 @@ public class UserService {
                 .build());
         user.updateUserProfile(userProfileUpdateDto.getIntroduction(), userProfileImage);
 
-        return true;
+        return Boolean.TRUE;
     }
 
     public Boolean deleteUser(Long userId) {
         userRepository.deleteById(userId);
-
-        return true;
+        return Boolean.TRUE;
     }
 }

--- a/src/main/java/org/dongguk/jjoin/service/UserService.java
+++ b/src/main/java/org/dongguk/jjoin/service/UserService.java
@@ -31,23 +31,22 @@ public class UserService {
 
     public List<ClubCardDto> readUserClubs(Long userId) {
         User user = userRepository.findById(userId).orElseThrow(() -> new RuntimeException()); // 예외처리 수정 예정
-        List<Club> clubList = clubMemberRepository.findUserClubsByUser(user);
-        List<ClubCardDto> clubCardDtoList = new ArrayList<>();
+        List<Club> clubs = clubMemberRepository.findUserClubsByUser(user);
+        List<ClubCardDto> clubCardDtos = new ArrayList<>();
 
-        for (Club club : clubList) {
-            clubCardDtoList.add(ClubCardDto.builder()
-                    .clubId(club.getId())
-                    .clubName(club.getName())
+        for (Club club : clubs) {
+            clubCardDtos.add(ClubCardDto.builder()
+                    .id(club.getId())
+                    .name(club.getName())
                     .introduction(club.getIntroduction())
                     .leaderName(club.getLeader().getName())
-                    .userNumber(clubMemberRepository.countAllByClub(club))
+                    .numberOfMembers(clubMemberRepository.countAllByClub(club))
                     .dependent(club.getDependent().toString())
                     .profileImageUuid(club.getClubImage().getUuidName())
                     .newestNotice(noticeRepository.findByClubOrderByCreatedDateDesc(club).getTitle())
                     .build());
         }
-
-        return clubCardDtoList;
+        return clubCardDtos;
     }
 
     public UserProfileDto readUserProfile(Long userId) {


### PR DESCRIPTION
마이페이지에서의 API와 앱 홈화면에서 가입하 동아리 조회, 매니저의 개설신청서 CRUD에서 발생할 수 있는 버그를 수정했습니다.

- 가입한 동아리
- 사용자 조회
- 사용자 동아리 조회
- 프로필 변경
- 회원 탈퇴
- 동아리 개설 신청서 목록 조회
- 동아리 개설
- 동아리 개설 신청서 조회


**관련 이슈** 
> [FIX] 마이페이지 및 동아리 조회, 개설신청서 CRUD 수정 https://github.com/In-lyeog-sa-mu-so/jjoin-server/issues/72

**고려해봐야할 부분**

> 아마도 계속해서 버그가 발생할 것 같아서 통합 테스트를 한번 해야할 것 같습니다.