### PR TITLE
🐛 Fix : ResponseDto에 페이지네이션 정보 추가

### DIFF
--- a/src/main/java/org/dongguk/jjoin/controller/ClubController.java
+++ b/src/main/java/org/dongguk/jjoin/controller/ClubController.java
@@ -1,6 +1,7 @@
 package org.dongguk.jjoin.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.dongguk.jjoin.dto.page.NoticeAppPageDto;
 import org.dongguk.jjoin.dto.request.ApplicationAnswerDto;
 import org.dongguk.jjoin.dto.response.*;
 import org.dongguk.jjoin.service.AlbumService;
@@ -31,12 +32,10 @@ public class ClubController {
 
     // 동아리 게시글(공지, 홍보) 목록을 보여주는 API
     @GetMapping("/{clubId}/notices")
-    public Map<String, Object> readNotices(@PathVariable Long clubId,
-                                                @RequestParam("page") Long page,
-                                                @RequestParam("size") Long size) {
-        Map<String, Object> result = new HashMap<>();
-        result.put("data", clubService.readNotices(clubId, page, size));
-        return result;
+    public NoticeAppPageDto readNotices(@PathVariable Long clubId,
+                                        @RequestParam("page") Integer page,
+                                        @RequestParam("size") Integer size) {
+        return clubService.readNotices(clubId, page, size);
     }
 
     // 동아리 게시글 상세정보를 보여주는 API

--- a/src/main/java/org/dongguk/jjoin/controller/ManagerController.java
+++ b/src/main/java/org/dongguk/jjoin/controller/ManagerController.java
@@ -2,6 +2,7 @@ package org.dongguk.jjoin.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.dongguk.jjoin.dto.page.ApplicationPageDto;
 import org.dongguk.jjoin.dto.page.NoticeWebPageDto;
 import org.dongguk.jjoin.dto.request.*;
 import org.dongguk.jjoin.dto.response.*;
@@ -46,12 +47,13 @@ public class ManagerController {
         return managerService.showNoticeList(clubId, page, size);
     }
 
-    // 동아리 게시글 상세보성
+    // 동아리 게시글 상세보기
     @GetMapping("/club/{clubId}/notice/{noticeId}")
     public NoticeDto readNotice(@PathVariable Long clubId, @PathVariable Long noticeId) {
         return managerService.readNotice(clubId, noticeId);
     }
 
+    // 동아리 게시글 수정
     @PutMapping("/club/{clubId}/notice/{noticeId}")
     public void updateNotice(@PathVariable Long clubId, @PathVariable Long noticeId, @RequestBody NoticeRequestDto noticeRequestDto) {
         managerService.updateNotice(clubId, noticeId, noticeRequestDto);
@@ -181,10 +183,8 @@ public class ManagerController {
 
     // 동아리 가입 신청 목록
     @GetMapping("/club/{clubId}/application")
-    public Map<String, Object> readApplicationList(@PathVariable Long clubId, @RequestParam("page") Integer page, @RequestParam("size") Integer size){
-        Map<String, Object> result = new HashMap<>();
-        result.put("data", managerService.readApplicationList(clubId, page, size));
-        return result;
+    public ApplicationPageDto readApplicationList(@PathVariable Long clubId, @RequestParam("page") Integer page, @RequestParam("size") Integer size){
+        return managerService.readApplicationList(clubId, page, size);
     }
 
     // 동아리 가입 신청 상세보기

--- a/src/main/java/org/dongguk/jjoin/controller/ManagerController.java
+++ b/src/main/java/org/dongguk/jjoin/controller/ManagerController.java
@@ -3,6 +3,7 @@ package org.dongguk.jjoin.controller;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.dongguk.jjoin.dto.page.ApplicationPageDto;
+import org.dongguk.jjoin.dto.page.ClubMemberPageDto;
 import org.dongguk.jjoin.dto.page.NoticeWebPageDto;
 import org.dongguk.jjoin.dto.request.*;
 import org.dongguk.jjoin.dto.response.*;
@@ -99,10 +100,8 @@ public class ManagerController {
 
     // 동아리 멤버 목록 조회
     @GetMapping("/club/{clubId}/member")
-    public Map<String, Object> readClubMembers(@PathVariable Long clubId, @RequestParam("page") Integer page, @RequestParam("size") Integer size) {
-        Map<String, Object> result = new HashMap<>();
-        result.put("data", managerService.readClubMembers(clubId, page, size));
-        return result;
+    public ClubMemberPageDto readClubMembers(@PathVariable Long clubId, @RequestParam("page") Integer page, @RequestParam("size") Integer size) {
+        return managerService.readClubMembers(clubId, page, size);
     }
 
     // 동아리 멤버 권한 수정

--- a/src/main/java/org/dongguk/jjoin/controller/ManagerController.java
+++ b/src/main/java/org/dongguk/jjoin/controller/ManagerController.java
@@ -2,6 +2,7 @@ package org.dongguk.jjoin.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.dongguk.jjoin.dto.page.NoticeWebPageDto;
 import org.dongguk.jjoin.dto.request.*;
 import org.dongguk.jjoin.dto.response.*;
 import org.dongguk.jjoin.service.EnrollmentService;
@@ -32,19 +33,20 @@ public class ManagerController {
         return result;
     }
 
+    // 동아리 게시글 생성
     @PostMapping("/club/{clubId}/notice")
     public void createNotice(@PathVariable Long clubId, @RequestBody NoticeRequestDto noticeRequestDto) {
         Long userId = 1L;   //  로그인 구현시 @GetUser 같은 어노테이션으로 대체해야함
         managerService.createNotice(userId, clubId, noticeRequestDto);
     }
 
+    // 동아리 게시글 목록 조회
     @GetMapping("/club/{clubId}/notice")
-    public Map<String, Object> showNoticeList(@PathVariable Long clubId, @RequestParam("page") Integer page, @RequestParam("size") Integer size) {
-        Map<String, Object> result = new HashMap<>();
-        result.put("data", managerService.showNoticeList(clubId, page, size));
-        return result;
+    public NoticeWebPageDto showNoticeList(@PathVariable Long clubId, @RequestParam("page") Integer page, @RequestParam("size") Integer size) {
+        return managerService.showNoticeList(clubId, page, size);
     }
 
+    // 동아리 게시글 상세보성
     @GetMapping("/club/{clubId}/notice/{noticeId}")
     public NoticeDto readNotice(@PathVariable Long clubId, @PathVariable Long noticeId) {
         return managerService.readNotice(clubId, noticeId);

--- a/src/main/java/org/dongguk/jjoin/controller/SearchController.java
+++ b/src/main/java/org/dongguk/jjoin/controller/SearchController.java
@@ -1,6 +1,7 @@
 package org.dongguk.jjoin.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.dongguk.jjoin.dto.page.SearchClubPageDto;
 import org.dongguk.jjoin.dto.response.SearchClubDto;
 import org.dongguk.jjoin.dto.response.TagDto;
 import org.dongguk.jjoin.service.SearchService;
@@ -18,11 +19,11 @@ import java.util.Map;
 @RequestMapping("/search")
 public class SearchController {
     private final SearchService searchService;
+
+    // 동아리 검색 API
     @GetMapping
-    public Map<String, Object> searchClubs(@RequestParam String keyword, @RequestParam List<String> tags, @RequestParam Integer page, @RequestParam Integer size){
-        Map<String, Object> result = new HashMap<>();
-        result.put("clubs", searchService.searchClubs(keyword, tags, page, size));
-        return result;
+    public SearchClubPageDto searchClubs(@RequestParam String keyword, @RequestParam List<String> tags, @RequestParam Integer page, @RequestParam Integer size){
+        return searchService.searchClubs(keyword, tags, page, size);
     }
 
     // 동아리 검색하기 위해 모든 태그 목록 조회

--- a/src/main/java/org/dongguk/jjoin/controller/SearchController.java
+++ b/src/main/java/org/dongguk/jjoin/controller/SearchController.java
@@ -2,6 +2,7 @@ package org.dongguk.jjoin.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.dongguk.jjoin.dto.page.SearchClubPageDto;
+import org.dongguk.jjoin.dto.page.TagPageDto;
 import org.dongguk.jjoin.dto.response.SearchClubDto;
 import org.dongguk.jjoin.dto.response.TagDto;
 import org.dongguk.jjoin.service.SearchService;
@@ -28,9 +29,7 @@ public class SearchController {
 
     // 동아리 검색하기 위해 모든 태그 목록 조회
     @GetMapping("/tags")
-    public Map<String, Object> readAllTags() {
-        Map<String, Object> result = new HashMap<>();
-        result.put("clubs", searchService.readAllTags());
-        return result;
+    public TagPageDto readAllTags(@RequestParam Integer page, @RequestParam Integer size) {
+        return searchService.readAllTags(page, size);
     }
 }

--- a/src/main/java/org/dongguk/jjoin/dto/page/ApplicationPageDto.java
+++ b/src/main/java/org/dongguk/jjoin/dto/page/ApplicationPageDto.java
@@ -1,0 +1,21 @@
+package org.dongguk.jjoin.dto.page;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.dongguk.jjoin.dto.response.ApplicationDto;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+public class ApplicationPageDto {
+    private List<ApplicationDto> data;
+    private PageInfo pageInfo;
+
+    @Builder
+    public ApplicationPageDto(List<ApplicationDto> data, PageInfo pageInfo) {
+        this.data = data;
+        this.pageInfo = pageInfo;
+    }
+}

--- a/src/main/java/org/dongguk/jjoin/dto/page/ClubMemberPageDto.java
+++ b/src/main/java/org/dongguk/jjoin/dto/page/ClubMemberPageDto.java
@@ -1,0 +1,21 @@
+package org.dongguk.jjoin.dto.page;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.dongguk.jjoin.dto.response.ClubMemberDto;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+public class ClubMemberPageDto {
+    private List<ClubMemberDto> data;
+    private PageInfo pageInfo;
+
+    @Builder
+    public ClubMemberPageDto(List<ClubMemberDto> data, PageInfo pageInfo) {
+        this.data = data;
+        this.pageInfo = pageInfo;
+    }
+}

--- a/src/main/java/org/dongguk/jjoin/dto/page/NoticeAppPageDto.java
+++ b/src/main/java/org/dongguk/jjoin/dto/page/NoticeAppPageDto.java
@@ -1,0 +1,21 @@
+package org.dongguk.jjoin.dto.page;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.dongguk.jjoin.dto.response.NoticeListDtoByApp;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+public class NoticeAppPageDto {
+    private List<NoticeListDtoByApp> noticeListDtoByApps;
+    private PageInfo pageInfo;
+
+    @Builder
+    public NoticeAppPageDto(List<NoticeListDtoByApp> noticeListDtoByApps, PageInfo pageInfo) {
+        this.noticeListDtoByApps = noticeListDtoByApps;
+        this.pageInfo = pageInfo;
+    }
+}

--- a/src/main/java/org/dongguk/jjoin/dto/page/NoticeWebPageDto.java
+++ b/src/main/java/org/dongguk/jjoin/dto/page/NoticeWebPageDto.java
@@ -3,18 +3,19 @@ package org.dongguk.jjoin.dto.page;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.dongguk.jjoin.dto.response.NoticeListDtoByApp;
+import org.dongguk.jjoin.dto.response.NoticeListDto;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
 @Data
 @NoArgsConstructor
-public class NoticeAppPageDto {
-    private List<NoticeListDtoByApp> data;
+public class NoticeWebPageDto {
+    private List<NoticeListDto> data;
     private PageInfo pageInfo;
 
     @Builder
-    public NoticeAppPageDto(List<NoticeListDtoByApp> data, PageInfo pageInfo) {
+    public NoticeWebPageDto(List<NoticeListDto> data, PageInfo pageInfo) {
         this.data = data;
         this.pageInfo = pageInfo;
     }

--- a/src/main/java/org/dongguk/jjoin/dto/page/PageInfo.java
+++ b/src/main/java/org/dongguk/jjoin/dto/page/PageInfo.java
@@ -1,0 +1,20 @@
+package org.dongguk.jjoin.dto.page;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class PageInfo {
+    private int page;
+    private int size;
+    private Long totalElements;
+    private int totalPages;
+
+    @Builder
+    public PageInfo(int page, int size, Long totalElements, int totalPages) {
+        this.page = page;
+        this.size = size;
+        this.totalElements = totalElements;
+        this.totalPages = totalPages;
+    }
+}

--- a/src/main/java/org/dongguk/jjoin/dto/page/SearchClubPageDto.java
+++ b/src/main/java/org/dongguk/jjoin/dto/page/SearchClubPageDto.java
@@ -1,6 +1,5 @@
 package org.dongguk.jjoin.dto.page;
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;

--- a/src/main/java/org/dongguk/jjoin/dto/page/SearchClubPageDto.java
+++ b/src/main/java/org/dongguk/jjoin/dto/page/SearchClubPageDto.java
@@ -1,0 +1,22 @@
+package org.dongguk.jjoin.dto.page;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.dongguk.jjoin.dto.response.SearchClubDto;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+public class SearchClubPageDto {
+    private List<SearchClubDto> clubs;
+    private PageInfo pageInfo;
+
+    @Builder
+    public SearchClubPageDto(List<SearchClubDto> clubs, PageInfo pageInfo) {
+        this.clubs = clubs;
+        this.pageInfo = pageInfo;
+    }
+}

--- a/src/main/java/org/dongguk/jjoin/dto/page/TagPageDto.java
+++ b/src/main/java/org/dongguk/jjoin/dto/page/TagPageDto.java
@@ -1,0 +1,21 @@
+package org.dongguk.jjoin.dto.page;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.dongguk.jjoin.dto.response.TagDto;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+public class TagPageDto {
+    private List<TagDto> data;
+    private PageInfo pageInfo;
+
+    @Builder
+    public TagPageDto(List<TagDto> data, PageInfo pageInfo) {
+        this.data = data;
+        this.pageInfo = pageInfo;
+    }
+}

--- a/src/main/java/org/dongguk/jjoin/dto/response/ClubMemberDto.java
+++ b/src/main/java/org/dongguk/jjoin/dto/response/ClubMemberDto.java
@@ -1,15 +1,14 @@
-package org.dongguk.jjoin.dto;
+package org.dongguk.jjoin.dto.response;
 
 import lombok.Builder;
 import lombok.Getter;
-import org.dongguk.jjoin.domain.type.DependentType;
 import org.dongguk.jjoin.domain.type.MajorType;
 import org.dongguk.jjoin.domain.type.RankType;
 
 import java.sql.Timestamp;
 
 @Getter
-public class ClubMemberDtoByWeb {
+public class ClubMemberDto {
     private Long userId;
     private String userName;
     private Long studentId;
@@ -18,7 +17,7 @@ public class ClubMemberDtoByWeb {
     private RankType position;
 
     @Builder
-    public ClubMemberDtoByWeb(Long userId, String userName, MajorType major, Long studentId, Timestamp registerDate, RankType position) {
+    public ClubMemberDto(Long userId, String userName, MajorType major, Long studentId, Timestamp registerDate, RankType position) {
         this.userId = userId;
         this.userName = userName;
         this.major = major;

--- a/src/main/java/org/dongguk/jjoin/repository/ApplicationRepository.java
+++ b/src/main/java/org/dongguk/jjoin/repository/ApplicationRepository.java
@@ -1,6 +1,7 @@
 package org.dongguk.jjoin.repository;
 
 import org.dongguk.jjoin.domain.ClubApplication;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -13,7 +14,7 @@ import java.util.Optional;
 @Repository
 public interface ApplicationRepository extends JpaRepository<ClubApplication, Long> {
     @Query("SELECT ca FROM ClubApplication AS ca WHERE ca.club.id = :clubId ORDER BY ca.requestDate")
-    List<ClubApplication> findApplicationList(@Param("clubId") Long clubId, Pageable pageable);
+    Page<ClubApplication> findApplicationList(@Param("clubId") Long clubId, Pageable pageable);
 
     Optional<ClubApplication> findById(Long clubApplication_id);
 

--- a/src/main/java/org/dongguk/jjoin/repository/ClubMemberRepository.java
+++ b/src/main/java/org/dongguk/jjoin/repository/ClubMemberRepository.java
@@ -22,7 +22,7 @@ public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
 
     Long countAllByClub(Club club);
 
-    List<ClubMember> findByClubId(Long clubId, Pageable pageable);
+    Page<ClubMember> findByClubId(Long clubId, Pageable pageable);
 
     @Query("SELECT cm FROM ClubMember AS cm WHERE cm.club.id = :clubId AND cm.user.id = :userId")
     Optional<ClubMember> findClubMemberByClubIdAndUserId(@Param("clubId") Long clubId, @Param("userId") Long userId);

--- a/src/main/java/org/dongguk/jjoin/repository/ClubRepository.java
+++ b/src/main/java/org/dongguk/jjoin/repository/ClubRepository.java
@@ -2,6 +2,8 @@ package org.dongguk.jjoin.repository;
 
 import org.dongguk.jjoin.domain.Club;
 import org.dongguk.jjoin.domain.Tag;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -14,13 +16,14 @@ import java.util.Optional;
 public interface ClubRepository extends JpaRepository<Club, Long> {
     @Query("SELECT c FROM Club AS c JOIN ClubTag AS ct ON ct.club = c WHERE ct.tag IN :tagList AND c.isDeleted = FALSE " +
             "AND c.createdDate != null")
-    List<Club> findClubsByTags(@Param("tagList") List<Tag> tagList);
+    Page<Club> findClubsByTags(@Param("tagList") List<Tag> tagList, Pageable pageable);
 
     @Query("SELECT c FROM Club AS c JOIN ClubTag AS ct ON ct.club = c WHERE ct.tag IN :tagList " +
             "AND (c.name LIKE %:keyword% OR c.introduction LIKE %:keyword%) AND c.isDeleted = FALSE " +
             "AND c.createdDate != null")
-    List<Club> findClubsByTagsAndKeyword(@Param("tagList") List<Tag> tagList, @Param("keyword") String keyword);
+    Page<Club> findClubsByTagsAndKeyword(@Param("tagList") List<Tag> tagList, @Param("keyword") String keyword, Pageable pageable);
 
     // 검색 키워드로 클럽 검색
-    List<Club> findClubsByNameContainingOrIntroductionContainingAndIsDeletedIsFalseAndCreatedDateIsNotNull(String keyword, String keyword2);
+    Page<Club> findClubsByNameContainingOrIntroductionContainingAndIsDeletedIsFalseAndCreatedDateIsNotNull(String keyword, String keyword2, Pageable pageable);
+    Page<Club> findAll(Pageable pageable);
 }

--- a/src/main/java/org/dongguk/jjoin/repository/NoticeRepository.java
+++ b/src/main/java/org/dongguk/jjoin/repository/NoticeRepository.java
@@ -2,10 +2,17 @@ package org.dongguk.jjoin.repository;
 
 import org.dongguk.jjoin.domain.Club;
 import org.dongguk.jjoin.domain.Notice;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
     Notice findFirstByClubOrderByCreatedDateDesc(Club club);
+
+    @Query("SELECT n FROM Notice AS n WHERE n.club = :club AND n.isDeleted = FALSE")
+    Page<Notice> findAllByClubAndNotDeleted(@Param("club") Club club, Pageable pageable);
 }

--- a/src/main/java/org/dongguk/jjoin/repository/TagRepository.java
+++ b/src/main/java/org/dongguk/jjoin/repository/TagRepository.java
@@ -1,6 +1,8 @@
 package org.dongguk.jjoin.repository;
 
 import org.dongguk.jjoin.domain.Tag;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -14,5 +16,5 @@ public interface TagRepository extends JpaRepository<Tag, Long> {
     List<Tag> findByNames(@Param("names") List<String> names);
 
     @Query("SELECT t FROM Tag AS t ORDER BY t.name")
-    List<Tag> findAllSort();
+    Page<Tag> findAllSort(Pageable pageable);
 }

--- a/src/main/java/org/dongguk/jjoin/service/ClubService.java
+++ b/src/main/java/org/dongguk/jjoin/service/ClubService.java
@@ -54,7 +54,7 @@ public class ClubService {
                     .updatedDate(notice.getUpdatedDate()).build());
         }
         return NoticeAppPageDto.builder()
-                .noticeListDtoByApps(noticeListDtoByApps)
+                .data(noticeListDtoByApps)
                 .pageInfo(PageInfo.builder()
                         .page(page)
                         .size(size)

--- a/src/main/java/org/dongguk/jjoin/service/ClubService.java
+++ b/src/main/java/org/dongguk/jjoin/service/ClubService.java
@@ -5,9 +5,15 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.dongguk.jjoin.domain.Club;
 import org.dongguk.jjoin.domain.Notice;
+import org.dongguk.jjoin.dto.page.NoticeAppPageDto;
+import org.dongguk.jjoin.dto.page.PageInfo;
 import org.dongguk.jjoin.dto.request.ApplicationAnswerDto;
 import org.dongguk.jjoin.dto.response.*;
 import org.dongguk.jjoin.repository.*;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.dongguk.jjoin.domain.*;
@@ -31,25 +37,31 @@ public class ClubService {
     private final ApplicationRepository applicationRepository;
     private final AnswerRepository answerRepository;
     private final TagRepository tagRepository;
+    private final NoticeRepository noticeRepository;
 
     // 동아리 게시글(공지, 홍보) 목록 반환
-    public List<NoticeListDtoByApp> readNotices(Long clubId, Long page, Long size) {
+    public NoticeAppPageDto readNotices(Long clubId, Integer page, Integer size) {
         Club club = clubRepository.findById(clubId).orElseThrow(() -> new RuntimeException("no match clubId"));
-        List<Notice> notices = club.getNotices();
-        notices.removeIf(notice -> notice.isDeleted());
-        notices.sort(Comparator.comparing(Notice::getUpdatedDate).reversed());
-        int startIdx = page.intValue() * size.intValue();
-        List<Notice> showNotices = notices.subList(startIdx, Math.min(startIdx + size.intValue(), notices.size()));
+        Pageable pageable = PageRequest.of(page, size, Sort.by("updatedDate").descending());
+        Page<Notice> notices = noticeRepository.findAllByClubAndNotDeleted(club, pageable);
         List<NoticeListDtoByApp> noticeListDtoByApps = new ArrayList<>();
 
-        for (Notice notice : showNotices) {
+        for (Notice notice : notices) {
             noticeListDtoByApps.add(NoticeListDtoByApp.builder()
                     .id(notice.getId())
                     .title(notice.getTitle())
                     .content(notice.getContent())
                     .updatedDate(notice.getUpdatedDate()).build());
         }
-        return noticeListDtoByApps;
+        return NoticeAppPageDto.builder()
+                .noticeListDtoByApps(noticeListDtoByApps)
+                .pageInfo(PageInfo.builder()
+                        .page(page)
+                        .size(size)
+                        .totalElements(notices.getTotalElements())
+                        .totalPages(notices.getTotalPages())
+                        .build())
+                .build();
     }
 
     // 동아리 게시글 상세정보를 보여주는 API

--- a/src/main/java/org/dongguk/jjoin/service/ManagerService.java
+++ b/src/main/java/org/dongguk/jjoin/service/ManagerService.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.dongguk.jjoin.domain.*;
 import org.dongguk.jjoin.domain.type.ImageType;
 import org.dongguk.jjoin.domain.type.RankType;
+import org.dongguk.jjoin.dto.page.ApplicationPageDto;
 import org.dongguk.jjoin.dto.page.NoticeWebPageDto;
 import org.dongguk.jjoin.dto.page.PageInfo;
 import org.dongguk.jjoin.dto.request.ApplicationQuestionDto;
@@ -97,7 +98,6 @@ public class ManagerService {
                 .build();
     }
 
-
     public Notice searchNotice(Long clubId, Long noticeId) {
         Club club = clubRepository.findById(clubId).orElseThrow(() -> new RuntimeException("no match clubId"));
         Notice notice = club.getNotices().stream()
@@ -117,6 +117,7 @@ public class ManagerService {
                 .updatedDate(notice.getUpdatedDate()).build();
     }
 
+    // 동아리 게시글 수정
     public void updateNotice(Long clubId, Long noticeId, NoticeRequestDto noticeRequestDto) {
         Notice notice = searchNotice(clubId, noticeId);
 
@@ -286,16 +287,24 @@ public class ManagerService {
     }
 
     // 동아리 가입 신청 목록
-    public List<ApplicationDto> readApplicationList(Long clubId, Integer page, Integer size) {
+    public ApplicationPageDto readApplicationList(Long clubId, Integer page, Integer size) {
         clubRepository.findById(clubId).orElseThrow(() -> new RuntimeException("NO Club"));
         PageRequest pageRequest = PageRequest.of(page, size);
-        List<ClubApplication> clubApplications = applicationRepository.findApplicationList(clubId, pageRequest);
+        Page<ClubApplication> clubApplications = applicationRepository.findApplicationList(clubId, pageRequest);
         List<ApplicationDto> applicationDtos = new ArrayList<>();
 
         for (ClubApplication clubApplication : clubApplications) {
             applicationDtos.add(makeApplicationDto(clubApplication));
         }
-        return applicationDtos;
+        return ApplicationPageDto.builder()
+                .data(applicationDtos)
+                .pageInfo(PageInfo.builder()
+                        .page(page)
+                        .size(size)
+                        .totalElements(clubApplications.getTotalElements())
+                        .totalPages(clubApplications.getTotalPages())
+                        .build())
+                .build();
     }
 
     // 동아리 가입 신청 상세보기

--- a/src/main/java/org/dongguk/jjoin/service/ManagerService.java
+++ b/src/main/java/org/dongguk/jjoin/service/ManagerService.java
@@ -5,6 +5,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.dongguk.jjoin.domain.*;
 import org.dongguk.jjoin.domain.type.ImageType;
 import org.dongguk.jjoin.domain.type.RankType;
+import org.dongguk.jjoin.dto.page.NoticeWebPageDto;
+import org.dongguk.jjoin.dto.page.PageInfo;
 import org.dongguk.jjoin.dto.request.ApplicationQuestionDto;
 import org.dongguk.jjoin.dto.request.QuestionDeleteDto;
 import org.dongguk.jjoin.dto.request.QuestionModifyDto;
@@ -16,7 +18,10 @@ import org.dongguk.jjoin.dto.response.NoticeDto;
 import org.dongguk.jjoin.dto.response.NoticeListDto;
 import org.dongguk.jjoin.repository.*;
 import org.dongguk.jjoin.util.FileUtil;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -55,24 +60,7 @@ public class ManagerService {
         return managingClubDtos;
     }
 
-    public List<NoticeListDto> showNoticeList(Long clubId, Integer page, Integer size){
-        Club club = clubRepository.findById(clubId).orElseThrow(()-> new RuntimeException("no match clubId"));
-        List<Notice> notices = Optional.ofNullable(club.getNotices()).orElseThrow(()-> new RuntimeException("Notice Not found!"));
-        notices.removeIf(notice -> notice.isDeleted());
-        notices.sort(Comparator.comparing(Notice::getUpdatedDate).reversed());
-
-        int startIdx = page * size;
-        List<Notice> showNotices = notices.subList(startIdx, Math.min(startIdx + size, notices.size()));
-        List<NoticeListDto> noticeListDtos = new ArrayList<>();
-        for (Notice n : showNotices) {
-            noticeListDtos.add(NoticeListDto.builder()
-                    .id(n.getId())
-                    .title(n.getTitle())
-                    .updatedDate(n.getUpdatedDate()).build());
-        }
-        return noticeListDtos;
-    }
-
+    // 동아리 게시글 생성
     public void createNotice(Long userId, Long clubId, NoticeRequestDto noticeRequestDto) {
         // 유저 유무, 클럽 존재유무 확인
         //User user = userRepository.findById(userId).orElseThrow(()-> new RuntimeException("createNotice club없음!"));
@@ -84,6 +72,31 @@ public class ManagerService {
                 .content(noticeRequestDto.getContent())
                 .club(club).build());
     }
+
+    // 동아리 게시글 목록 조회
+    public NoticeWebPageDto showNoticeList(Long clubId, Integer page, Integer size){
+        Club club = clubRepository.findById(clubId).orElseThrow(()-> new RuntimeException("no match clubId"));
+        Pageable pageable = PageRequest.of(page, size, Sort.by("updatedDate").descending());
+        Page<Notice> notices = noticeRepository.findAllByClubAndNotDeleted(club, pageable);
+
+        List<NoticeListDto> noticeListDtos = new ArrayList<>();
+        for (Notice n : notices) {
+            noticeListDtos.add(NoticeListDto.builder()
+                    .id(n.getId())
+                    .title(n.getTitle())
+                    .updatedDate(n.getUpdatedDate()).build());
+        }
+        return NoticeWebPageDto.builder()
+                .data(noticeListDtos)
+                .pageInfo(PageInfo.builder()
+                        .page(page)
+                        .size(size)
+                        .totalElements(notices.getTotalElements())
+                        .totalPages(notices.getTotalPages())
+                        .build())
+                .build();
+    }
+
 
     public Notice searchNotice(Long clubId, Long noticeId) {
         Club club = clubRepository.findById(clubId).orElseThrow(() -> new RuntimeException("no match clubId"));

--- a/src/main/java/org/dongguk/jjoin/service/ManagerService.java
+++ b/src/main/java/org/dongguk/jjoin/service/ManagerService.java
@@ -6,6 +6,7 @@ import org.dongguk.jjoin.domain.*;
 import org.dongguk.jjoin.domain.type.ImageType;
 import org.dongguk.jjoin.domain.type.RankType;
 import org.dongguk.jjoin.dto.page.ApplicationPageDto;
+import org.dongguk.jjoin.dto.page.ClubMemberPageDto;
 import org.dongguk.jjoin.dto.page.NoticeWebPageDto;
 import org.dongguk.jjoin.dto.page.PageInfo;
 import org.dongguk.jjoin.dto.request.ApplicationQuestionDto;
@@ -13,7 +14,7 @@ import org.dongguk.jjoin.dto.request.QuestionDeleteDto;
 import org.dongguk.jjoin.dto.request.QuestionModifyDto;
 import org.dongguk.jjoin.dto.request.NoticeRequestDto;
 import org.dongguk.jjoin.dto.response.*;
-import org.dongguk.jjoin.dto.ClubMemberDtoByWeb;
+import org.dongguk.jjoin.dto.response.ClubMemberDto;
 import org.dongguk.jjoin.dto.response.ClubMainPageUpdateDto;
 import org.dongguk.jjoin.dto.response.NoticeDto;
 import org.dongguk.jjoin.dto.response.NoticeListDto;
@@ -29,7 +30,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.sql.Timestamp;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
@@ -131,13 +131,13 @@ public class ManagerService {
     }
 
     // 동아리 멤버 목록 조회
-    public List<ClubMemberDtoByWeb> readClubMembers(Long clubId, Integer page, Integer size) {
+    public ClubMemberPageDto readClubMembers(Long clubId, Integer page, Integer size) {
         PageRequest pageRequest = PageRequest.of(page, size);
-        List<ClubMember> clubMembers = clubMemberRepository.findByClubId(clubId, pageRequest);
-        List<ClubMemberDtoByWeb> clubMemberDtoByWebs = new ArrayList<>();
+        Page<ClubMember> clubMembers = clubMemberRepository.findByClubId(clubId, pageRequest);
+        List<ClubMemberDto> clubMemberDtos = new ArrayList<>();
         for (ClubMember cm : clubMembers) {
             User user = cm.getUser();
-            clubMemberDtoByWebs.add(ClubMemberDtoByWeb.builder()
+            clubMemberDtos.add(ClubMemberDto.builder()
                     .userId(user.getId())
                     .userName(user.getName())
                     .major(user.getMajor())
@@ -146,7 +146,15 @@ public class ManagerService {
                     .position(cm.getRankType())
                     .build());
         }
-        return clubMemberDtoByWebs;
+        return ClubMemberPageDto.builder()
+                .data(clubMemberDtos)
+                .pageInfo(PageInfo.builder()
+                        .page(page)
+                        .size(size)
+                        .totalElements(clubMembers.getTotalElements())
+                        .totalPages(clubMembers.getTotalPages())
+                        .build())
+                .build();
     }
 
     // 동아리 멤버 권한 수정

--- a/src/main/java/org/dongguk/jjoin/service/SearchService.java
+++ b/src/main/java/org/dongguk/jjoin/service/SearchService.java
@@ -7,6 +7,7 @@ import org.dongguk.jjoin.domain.Recruited_period;
 import org.dongguk.jjoin.domain.Tag;
 import org.dongguk.jjoin.dto.page.PageInfo;
 import org.dongguk.jjoin.dto.page.SearchClubPageDto;
+import org.dongguk.jjoin.dto.page.TagPageDto;
 import org.dongguk.jjoin.dto.response.SearchClubDto;
 import org.dongguk.jjoin.dto.response.TagDto;
 import org.dongguk.jjoin.repository.*;
@@ -80,14 +81,25 @@ public class SearchService {
     }
 
     // 동아리 검색하기 위해 모든 태그 목록 조회
-    public List<TagDto> readAllTags() {
+    public TagPageDto readAllTags(Integer page, Integer size) {
+        Pageable pageable = PageRequest.of(page, size);
         List<TagDto> tagDtos = new ArrayList<>();
-        for (Tag tag : tagRepository.findAllSort()) {
+        Page<Tag> tags = tagRepository.findAllSort(pageable);
+
+        for (Tag tag : tags.getContent()) {
             tagDtos.add(TagDto.builder()
                     .id(tag.getId())
                     .name(tag.getName())
                     .build());
         }
-        return tagDtos;
+        return TagPageDto.builder()
+                .data(tagDtos)
+                .pageInfo(PageInfo.builder()
+                        .page(page)
+                        .size(size)
+                        .totalElements(tags.getTotalElements())
+                        .totalPages(tags.getTotalPages())
+                        .build())
+                .build();
     }
 }


### PR DESCRIPTION
페이지네이션이 필요한 API의 ResponseBody에 페이지네이션 정보를 담아서 반환합니다.

App
- 동아리 검색
- 동아리 검색시 태그 목록
- 동아리 게시글 목록

Web
 - 게시글 목록
- 가입 신청 목록
- 멤버 목록 조회

**관련 이슈**
> #89 