### PR TITLE
🐛 Fix : 동아리 멤버 조회시 email 값 추가해서 반환

### DIFF
--- a/src/main/java/org/dongguk/jjoin/dto/response/ClubMemberDto.java
+++ b/src/main/java/org/dongguk/jjoin/dto/response/ClubMemberDto.java
@@ -13,14 +13,16 @@ public class ClubMemberDto {
     private String userName;
     private Long studentId;
     private MajorType major;
+    private String email;
     private Timestamp registerDate;
     private RankType position;
 
     @Builder
-    public ClubMemberDto(Long userId, String userName, MajorType major, Long studentId, Timestamp registerDate, RankType position) {
+    public ClubMemberDto(Long userId, String userName, MajorType major, String email, Long studentId, Timestamp registerDate, RankType position) {
         this.userId = userId;
         this.userName = userName;
         this.major = major;
+        this.email = email;
         this.studentId = studentId;
         this.registerDate = registerDate;
         this.position = position;

--- a/src/main/java/org/dongguk/jjoin/service/ManagerService.java
+++ b/src/main/java/org/dongguk/jjoin/service/ManagerService.java
@@ -141,6 +141,7 @@ public class ManagerService {
                     .userId(user.getId())
                     .userName(user.getName())
                     .major(user.getMajor())
+                    .email(user.getEmail())
                     .studentId(user.getStudentId())
                     .registerDate(cm.getRegisterDate())
                     .position(cm.getRankType())


### PR DESCRIPTION
Web에서 동아리 멤버 조회시 email을 반환해줘야하는데 누락되어있어 추가해서 반환하도록 수정합니다.

**관련 이슈**
> #93 