### PR TITLE
✨ Feat: Web - 동아리 관리자 페이지 정보 추가 및 pageInfo 추가

### DIFF
--- a/src/main/java/org/dongguk/jjoin/controller/AdminController.java
+++ b/src/main/java/org/dongguk/jjoin/controller/AdminController.java
@@ -2,6 +2,8 @@ package org.dongguk.jjoin.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.dongguk.jjoin.dto.page.ClubDeletionPageDto;
+import org.dongguk.jjoin.dto.page.EnrollmentPageDto;
 import org.dongguk.jjoin.dto.request.ClubDeletionUpdateDto;
 import org.dongguk.jjoin.dto.request.EnrollmentUpdateDto;
 import org.dongguk.jjoin.dto.response.ClubDeletionDto;
@@ -26,10 +28,8 @@ public class AdminController {
 
     // 관리자가 동아리 개설 신청서를 읽어오는 API
     @GetMapping("/enrollment")
-    public Map<String, Object> readEnrollments(@RequestParam Long page, @RequestParam Long size) {
-        Map<String, Object> result = new HashMap<>();
-        result.put("data", enrollmentService.readEnrollments(page, size));
-        return result;
+    public EnrollmentPageDto readEnrollments(@RequestParam Long page, @RequestParam Long size) {
+        return enrollmentService.readEnrollments(page, size);
     }
 
     @GetMapping("/enrollment/{enrollmentId}")
@@ -51,10 +51,8 @@ public class AdminController {
 
     // 관리자가 동아리 삭제 신청 목록을 조회하는 API
     @GetMapping("/deletion")
-    public Map<String, Object> readClubDeletions(@RequestParam Long page, @RequestParam Long size) {
-        Map<String, Object> result = new HashMap<>();
-        result.put("data", clubDeletionService.readClubDeletions(page, size));
-        return result;
+    public ClubDeletionPageDto readClubDeletions(@RequestParam Long page, @RequestParam Long size) {
+        return clubDeletionService.readClubDeletions(page, size);
     }
 
     // 관리자가 동아리 삭제 신청을 승인하는 API

--- a/src/main/java/org/dongguk/jjoin/controller/ClubController.java
+++ b/src/main/java/org/dongguk/jjoin/controller/ClubController.java
@@ -1,6 +1,7 @@
 package org.dongguk.jjoin.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.dongguk.jjoin.dto.page.ClubSchedulePageDto;
 import org.dongguk.jjoin.dto.page.NoticeAppPageDto;
 import org.dongguk.jjoin.dto.request.ApplicationAnswerDto;
 import org.dongguk.jjoin.dto.response.*;
@@ -46,13 +47,11 @@ public class ClubController {
 
     // 특정 동아리의 일정 목록 조회 API
     @GetMapping("/{clubId}/schedules")
-    public Map<String, Object> readClubSchedules(@PathVariable Long clubId,
-                                                   @RequestParam("page") Long page,
-                                                   @RequestParam("size") Long size) {
+    public ClubSchedulePageDto readClubSchedules(@PathVariable Long clubId,
+                                                 @RequestParam("page") Long page,
+                                                 @RequestParam("size") Long size) {
         Long userId = 1L;
-        Map<String, Object> result = new HashMap<>();
-        result.put("data", scheduleService.readClubSchedules(userId, clubId, page, size));
-        return result;
+        return scheduleService.readClubSchedules(userId, clubId, page, size);
     }
 
     // 특정 동아리의 일정 상세 조회 API

--- a/src/main/java/org/dongguk/jjoin/controller/ManagerController.java
+++ b/src/main/java/org/dongguk/jjoin/controller/ManagerController.java
@@ -3,6 +3,7 @@ package org.dongguk.jjoin.controller;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.dongguk.jjoin.dto.page.ApplicationPageDto;
+import org.dongguk.jjoin.dto.page.ClubEnrollmentPageDto;
 import org.dongguk.jjoin.dto.page.ClubMemberPageDto;
 import org.dongguk.jjoin.dto.page.NoticeWebPageDto;
 import org.dongguk.jjoin.dto.request.*;
@@ -132,11 +133,9 @@ public class ManagerController {
 
     // 동아리 개설 신청서 목록 조회 API
     @GetMapping("/enrollment")
-    public Map<String, Object> readClubEnrollments() {
+    public ClubEnrollmentPageDto readClubEnrollments(@RequestParam("page") Integer page, @RequestParam("size") Integer size) {
         Long userId = 1L;
-        Map<String, Object> result = new HashMap<>();
-        result.put("data", enrollmentService.readClubEnrollments(userId));
-        return result;
+        return enrollmentService.readClubEnrollments(userId, page, size);
     }
 
     // 동아리 개설 API

--- a/src/main/java/org/dongguk/jjoin/dto/page/ClubDeletionPageDto.java
+++ b/src/main/java/org/dongguk/jjoin/dto/page/ClubDeletionPageDto.java
@@ -1,0 +1,19 @@
+package org.dongguk.jjoin.dto.page;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.dongguk.jjoin.dto.response.ClubDeletionDto;
+
+import java.util.List;
+
+@Getter
+public class ClubDeletionPageDto {
+    private List<ClubDeletionDto> data;
+    private PageInfo pageInfo;
+
+    @Builder
+    public ClubDeletionPageDto(List<ClubDeletionDto> data, PageInfo pageInfo) {
+        this.data = data;
+        this.pageInfo = pageInfo;
+    }
+}

--- a/src/main/java/org/dongguk/jjoin/dto/page/ClubEnrollmentPageDto.java
+++ b/src/main/java/org/dongguk/jjoin/dto/page/ClubEnrollmentPageDto.java
@@ -1,0 +1,19 @@
+package org.dongguk.jjoin.dto.page;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.dongguk.jjoin.dto.response.ClubEnrollmentDto;
+
+import java.util.List;
+
+@Getter
+public class ClubEnrollmentPageDto {
+    private List<ClubEnrollmentDto> data;
+    private PageInfo pageInfo;
+
+    @Builder
+    public ClubEnrollmentPageDto(List<ClubEnrollmentDto> data, PageInfo pageInfo) {
+        this.data = data;
+        this.pageInfo = pageInfo;
+    }
+}

--- a/src/main/java/org/dongguk/jjoin/dto/page/ClubSchedulePageDto.java
+++ b/src/main/java/org/dongguk/jjoin/dto/page/ClubSchedulePageDto.java
@@ -1,0 +1,19 @@
+package org.dongguk.jjoin.dto.page;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.dongguk.jjoin.dto.response.ClubScheduleDto;
+
+import java.util.List;
+
+@Getter
+public class ClubSchedulePageDto {
+    private List<ClubScheduleDto> data;
+    private PageInfo pageInfo;
+
+    @Builder
+    public ClubSchedulePageDto(List<ClubScheduleDto> data, PageInfo pageInfo) {
+        this.data = data;
+        this.pageInfo = pageInfo;
+    }
+}

--- a/src/main/java/org/dongguk/jjoin/dto/page/EnrollmentPageDto.java
+++ b/src/main/java/org/dongguk/jjoin/dto/page/EnrollmentPageDto.java
@@ -1,0 +1,19 @@
+package org.dongguk.jjoin.dto.page;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.dongguk.jjoin.dto.response.EnrollmentDto;
+
+import java.util.List;
+
+@Getter
+public class EnrollmentPageDto {
+    private List<EnrollmentDto> data;
+    private PageInfo pageInfo;
+
+    @Builder
+    public EnrollmentPageDto(List<EnrollmentDto> data, PageInfo pageInfo) {
+        this.data = data;
+        this.pageInfo = pageInfo;
+    }
+}

--- a/src/main/java/org/dongguk/jjoin/dto/response/ManagingClubDto.java
+++ b/src/main/java/org/dongguk/jjoin/dto/response/ManagingClubDto.java
@@ -7,10 +7,20 @@ import lombok.Getter;
 public class ManagingClubDto {
     private Long id;
     private String name;
+    private String introduction;
+    private String leaderName;
+    private Long numberOfMembers;
+    private String dependent;
+    private String profileImageUuid;
 
     @Builder
-    public ManagingClubDto(Long id, String name) {
+    public ManagingClubDto(Long id, String name, String introduction, String leaderName, Long numberOfMembers, String dependent, String profileImageUuid) {
         this.id = id;
         this.name = name;
+        this.introduction = introduction;
+        this.leaderName = leaderName;
+        this.numberOfMembers = numberOfMembers;
+        this.dependent = dependent;
+        this.profileImageUuid = profileImageUuid;
     }
 }

--- a/src/main/java/org/dongguk/jjoin/repository/EnrollmentRepository.java
+++ b/src/main/java/org/dongguk/jjoin/repository/EnrollmentRepository.java
@@ -2,6 +2,8 @@ package org.dongguk.jjoin.repository;
 
 import org.dongguk.jjoin.domain.Enrollment;
 import org.dongguk.jjoin.domain.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -14,7 +16,7 @@ import java.util.List;
 @Repository
 public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
     @Query(value = "SELECT e FROM Enrollment AS e WHERE e.club.leader = :user")
-    List<Enrollment> findByUser(@Param("user") User user);
+    Page<Enrollment> findByUser(@Param("user") User user, PageRequest pageable);
 
     @Modifying(clearAutomatically = true)
     @Query(value = "DELETE FROM Enrollment AS e WHERE e.id in :ids")

--- a/src/main/java/org/dongguk/jjoin/service/ClubDeletionService.java
+++ b/src/main/java/org/dongguk/jjoin/service/ClubDeletionService.java
@@ -4,6 +4,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.dongguk.jjoin.domain.Club;
 import org.dongguk.jjoin.domain.ClubDeletion;
+import org.dongguk.jjoin.dto.page.ClubDeletionPageDto;
+import org.dongguk.jjoin.dto.page.PageInfo;
 import org.dongguk.jjoin.dto.request.ClubDeletionUpdateDto;
 import org.dongguk.jjoin.dto.response.ClubDeletionDto;
 import org.dongguk.jjoin.repository.ClubDeletionRepository;
@@ -25,7 +27,7 @@ public class ClubDeletionService {
     private final ClubDeletionRepository clubDeletionRepository;
 
     // 동아리 삭제 신청서 반환
-    public List<ClubDeletionDto> readClubDeletions(Long page, Long size) {
+    public ClubDeletionPageDto readClubDeletions(Long page, Long size) {
         PageRequest pageable = PageRequest.of(page.intValue(), size.intValue(), Sort.by(Sort.Direction.DESC, "createdDate"));
         Page<ClubDeletion> clubDeletions = clubDeletionRepository.findAll(pageable);
         List<ClubDeletionDto> clubDeletionDtos = new ArrayList<>();
@@ -41,7 +43,16 @@ public class ClubDeletionService {
                     .createdDate(clubDeletion.getCreatedDate())
                     .build());
         }
-        return clubDeletionDtos;
+
+        return ClubDeletionPageDto.builder()
+                .data(clubDeletionDtos)
+                .pageInfo(PageInfo.builder()
+                        .page(page.intValue())
+                        .size(size.intValue())
+                        .totalElements(clubDeletions.getTotalElements())
+                        .totalPages(clubDeletions.getTotalPages())
+                        .build())
+                .build();
     }
 
     // 동아리 삭제 신청 승인

--- a/src/main/java/org/dongguk/jjoin/service/ManagerService.java
+++ b/src/main/java/org/dongguk/jjoin/service/ManagerService.java
@@ -56,6 +56,11 @@ public class ManagerService {
             managingClubDtos.add(ManagingClubDto.builder()
                     .id(club.getId())
                     .name(club.getName())
+                    .introduction(club.getIntroduction())
+                    .leaderName(club.getLeader().getName())
+                    .numberOfMembers(clubMemberRepository.countAllByClub(club))
+                    .dependent(club.getDependent().getDescription())
+                    .profileImageUuid(club.getClubImage().getUuidName())
                     .build());
         }
         return managingClubDtos;

--- a/src/main/java/org/dongguk/jjoin/service/ScheduleService.java
+++ b/src/main/java/org/dongguk/jjoin/service/ScheduleService.java
@@ -6,6 +6,8 @@ import org.dongguk.jjoin.domain.Club;
 import org.dongguk.jjoin.domain.Plan;
 import org.dongguk.jjoin.domain.Schedule;
 import org.dongguk.jjoin.domain.User;
+import org.dongguk.jjoin.dto.page.ClubSchedulePageDto;
+import org.dongguk.jjoin.dto.page.PageInfo;
 import org.dongguk.jjoin.dto.request.ScheduleDecideDto;
 import org.dongguk.jjoin.dto.response.ClubScheduleDetailDto;
 import org.dongguk.jjoin.dto.response.ClubScheduleDto;
@@ -123,7 +125,7 @@ public class ScheduleService {
     }
 
     // 특정 동아리의 일정 목록 반환
-    public List<ClubScheduleDto> readClubSchedules(Long userId, Long clubId, Long page, Long size) {
+    public ClubSchedulePageDto readClubSchedules(Long userId, Long clubId, Long page, Long size) {
         User user = userRepository.findById(userId).orElseThrow(() -> new RuntimeException()); // 예외처리 수정 예정
         Club club = clubRepository.findById(clubId).orElseThrow(() -> new RuntimeException("no match clubId"));
         PageRequest pageable = PageRequest.of(page.intValue(), size.intValue(), Sort.by(Sort.Direction.DESC, "createdDate"));
@@ -141,7 +143,15 @@ public class ScheduleService {
                     .isAgreed(schedule.getIsAgreed())
                     .build());
         }
-        return clubScheduleDtos;
+        return ClubSchedulePageDto.builder()
+                .data(clubScheduleDtos)
+                .pageInfo(PageInfo.builder()
+                        .page(page.intValue())
+                        .size(size.intValue())
+                        .totalElements(plans.getTotalElements())
+                        .totalPages(plans.getTotalPages())
+                        .build())
+                .build();
     }
 
     // 일정 상세 조회


### PR DESCRIPTION
동아리 관리자 페이지에서 사진 및 동아리 정보를 추가적으로 전달했고 pageInfo가 전달 안되던 부분도 다 추가해주었습니다.

- 동아리 관리자 메인 페이지 추가 정보 전달
- pageInfo 추가 전달
- 
**관련 이슈** 
[FEAT] 동아리 관리자 페이지 정보 추가 및 pageInfo 추가 https://github.com/In-lyeog-sa-mu-so/jjoin-server/issues/95

**고려해봐야할 부분**
페이징과 관련하여 dto 하나하나마다 추가할 필요없이 공통적으로 사용할 dto를 하나만들면 좋을 것 같습니다:)