### PR TITLE
🐛 FIX: Web - 게시글 번호 꼬임 문제 해결

### DIFF
--- a/src/main/java/org/dongguk/jjoin/controller/ClubController.java
+++ b/src/main/java/org/dongguk/jjoin/controller/ClubController.java
@@ -47,11 +47,13 @@ public class ClubController {
 
     // 특정 동아리의 일정 목록 조회 API
     @GetMapping("/{clubId}/schedules")
-    public ClubSchedulePageDto readClubSchedules(@PathVariable Long clubId,
+    public Map<String, Object> readClubSchedules(@PathVariable Long clubId,
                                                  @RequestParam("page") Long page,
                                                  @RequestParam("size") Long size) {
         Long userId = 1L;
-        return scheduleService.readClubSchedules(userId, clubId, page, size);
+        Map<String, Object> result = new HashMap<>();
+        result.put("data", scheduleService.readClubSchedules(userId, clubId, page, size));
+        return result;
     }
 
     // 특정 동아리의 일정 상세 조회 API

--- a/src/main/java/org/dongguk/jjoin/dto/response/NoticeListDto.java
+++ b/src/main/java/org/dongguk/jjoin/dto/response/NoticeListDto.java
@@ -8,13 +8,15 @@ import java.sql.Timestamp;
 @Getter
 public class NoticeListDto {
     private Long id;
+    private Long noticeNumber;
     private String title;
-    private Timestamp updatedDate;
+    private Timestamp createdDate;
 
     @Builder
-    public NoticeListDto(Long id, String title, Timestamp updatedDate) {
+    public NoticeListDto(Long id, Long noticeNumber, String title, Timestamp createdDate) {
         this.id = id;
+        this.noticeNumber = noticeNumber;
         this.title = title;
-        this.updatedDate = updatedDate;
+        this.createdDate = createdDate;
     }
 }

--- a/src/main/java/org/dongguk/jjoin/service/ManagerService.java
+++ b/src/main/java/org/dongguk/jjoin/service/ManagerService.java
@@ -82,23 +82,27 @@ public class ManagerService {
     // 동아리 게시글 목록 조회
     public NoticeWebPageDto showNoticeList(Long clubId, Integer page, Integer size){
         Club club = clubRepository.findById(clubId).orElseThrow(()-> new RuntimeException("no match clubId"));
-        Pageable pageable = PageRequest.of(page, size, Sort.by("updatedDate").descending());
+        Pageable pageable = PageRequest.of(page, size, Sort.by("createdDate").descending());
         Page<Notice> notices = noticeRepository.findAllByClubAndNotDeleted(club, pageable);
+        long totalElements = notices.getTotalElements();
+        int totalPages = notices.getTotalPages();
+        Long noticeNumber = totalElements - (page*size);
 
         List<NoticeListDto> noticeListDtos = new ArrayList<>();
-        for (Notice n : notices) {
+        for (Notice n : notices.getContent()) {
             noticeListDtos.add(NoticeListDto.builder()
                     .id(n.getId())
+                    .noticeNumber(noticeNumber--)
                     .title(n.getTitle())
-                    .updatedDate(n.getUpdatedDate()).build());
+                    .createdDate(n.getCreatedDate()).build());
         }
         return NoticeWebPageDto.builder()
                 .data(noticeListDtos)
                 .pageInfo(PageInfo.builder()
                         .page(page)
                         .size(size)
-                        .totalElements(notices.getTotalElements())
-                        .totalPages(notices.getTotalPages())
+                        .totalElements(totalElements)
+                        .totalPages(totalPages)
                         .build())
                 .build();
     }

--- a/src/main/java/org/dongguk/jjoin/service/ScheduleService.java
+++ b/src/main/java/org/dongguk/jjoin/service/ScheduleService.java
@@ -125,7 +125,7 @@ public class ScheduleService {
     }
 
     // 특정 동아리의 일정 목록 반환
-    public ClubSchedulePageDto readClubSchedules(Long userId, Long clubId, Long page, Long size) {
+    public List<ClubScheduleDto> readClubSchedules(Long userId, Long clubId, Long page, Long size) {
         User user = userRepository.findById(userId).orElseThrow(() -> new RuntimeException()); // 예외처리 수정 예정
         Club club = clubRepository.findById(clubId).orElseThrow(() -> new RuntimeException("no match clubId"));
         PageRequest pageable = PageRequest.of(page.intValue(), size.intValue(), Sort.by(Sort.Direction.DESC, "createdDate"));
@@ -143,15 +143,7 @@ public class ScheduleService {
                     .isAgreed(schedule.getIsAgreed())
                     .build());
         }
-        return ClubSchedulePageDto.builder()
-                .data(clubScheduleDtos)
-                .pageInfo(PageInfo.builder()
-                        .page(page.intValue())
-                        .size(size.intValue())
-                        .totalElements(plans.getTotalElements())
-                        .totalPages(plans.getTotalPages())
-                        .build())
-                .build();
+        return clubScheduleDtos;
     }
 
     // 일정 상세 조회


### PR DESCRIPTION
동아리 게시글 번호가 꼬이는 문제를 해결했습니다.

- 기존에 updateDate로 정렬하던 것을 createdDate 정렬로 수정
- 게시글 번호를 따로 계산하여 추

**관련 이슈** 
[FIX] 게시글 번호 꼬임 문제 해결 https://github.com/In-lyeog-sa-mu-so/jjoin-server/issues/98

**고려해봐야할 부분**