### PR TITLE
[REFACTOR] Web - 동아리 게시글 리팩토링

### DIFF
--- a/src/main/java/org/dongguk/jjoin/repository/NoticeRepository.java
+++ b/src/main/java/org/dongguk/jjoin/repository/NoticeRepository.java
@@ -9,10 +9,14 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
     Notice findFirstByClubOrderByCreatedDateDesc(Club club);
 
     @Query("SELECT n FROM Notice AS n WHERE n.club = :club AND n.isDeleted = FALSE")
     Page<Notice> findAllByClubAndNotDeleted(@Param("club") Club club, Pageable pageable);
+
+    Optional<Notice> findById(Long noticeId);
 }

--- a/src/main/java/org/dongguk/jjoin/service/ClubService.java
+++ b/src/main/java/org/dongguk/jjoin/service/ClubService.java
@@ -67,9 +67,7 @@ public class ClubService {
     // 동아리 게시글 상세정보를 보여주는 API
     public NoticeDto readNotice(Long clubId, Long noticeId) {
         Club club = clubRepository.findById(clubId).orElseThrow(() -> new RuntimeException("no match clubId"));
-        Notice notice = club.getNotices().stream()
-                .filter(n -> n.getId().equals(noticeId)).findAny()
-                .orElseThrow(() -> new RuntimeException("No match noticeId"));
+        Notice notice = noticeRepository.findById(noticeId).orElseThrow(() -> new RuntimeException("No match Notice"));
 
         return NoticeDto.builder()
                 .id(notice.getId())
@@ -147,9 +145,8 @@ public class ClubService {
     // 동아리 가입신청서 양식 가져오기
     public ApplicationFormDto readClubApplication(Long clubId) {
         Club club = clubRepository.findById(clubId).orElseThrow(() -> new RuntimeException("No match Club"));
-        Optional<Recruited_period> recruitedPeriod = recruitedPeriodRepository.findByClub(club);
-        // 모집 기간을 한번도 설정하지 않은 동아리라면 null값으로 설정
-        Timestamp period[] = recruitedPeriod.map(rp -> rp.getPeriod()).orElse(new Timestamp[]{null, null});
+        Recruited_period recruitedPeriod = recruitedPeriodRepository.findByClub(club).orElseThrow(() -> new RuntimeException("No match Recruited Period"));
+        Timestamp period[] = recruitedPeriod.getPeriod();
         List<Application_question> applicationQuestions = questionRepository.findAllByClubId(clubId);
         if (applicationQuestions == null || applicationQuestions.isEmpty()) {
             throw new RuntimeException("A Club has No application");
@@ -173,7 +170,7 @@ public class ClubService {
     // 동아리 가입신청서 제출
     public void submitClubApplication(Long clubId, List<ApplicationAnswerDto> applicationAnswerDtos) {
         clubRepository.findById(clubId).orElseThrow(() -> new RuntimeException("No match Club"));
-        User user = new User(); //User.getUser() 이 부분 수정 필요!!! 현재는 작동 안됨.
+        User user = userRepository.findById(8L).get(); //User.getUser() 이 부분 수정 필요!!! 현재는 무조건 8번 id를 가진 유저가 신청한 걸로 설정함.
         List<Application_answer> applicationAnswers = new ArrayList<>();
 
         for (ApplicationAnswerDto applicationAnswerDto : applicationAnswerDtos) {


### PR DESCRIPTION
초기에 짰던 동아리 게시글 조회하는 로직을 NoticeRepository를 활용해서 최적화할 수 있도록 수정하겠습니다.
추가로 앱에서 동아리 가입신청 지원시에 @GetUser로 로그인된 유저의 정보를 따와서 제출해야하는데 로그인이 아직 구현되지 않아 무조건 userId = 8 으로 지원신청이 되도록 코드를 수정했습니다.