### PR TITLE
🐛 FIX : 동아리 타입에 연합동아리 추가

### DIFF
--- a/src/main/java/org/dongguk/jjoin/domain/type/DependentType.java
+++ b/src/main/java/org/dongguk/jjoin/domain/type/DependentType.java
@@ -5,7 +5,7 @@ import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
 public enum DependentType {
-    MAJOR("학과"), CENTER("중앙");
+    MAJOR("학과"), CENTER("중앙"), UNION("연합");
 
     private final String description;
 


### PR DESCRIPTION
현재 동아리 타입인 DependentType에 학과(MAJOR), 중앙(CENTER) 동아리 밖에 없는데 연합 동아리 타입도 추가합니다.

**관련 이슈**
> #104 