### PR TITLE
🐛 FIX: Web - 유저 정보 및 동아리 정보 수정 오류 해결

### DIFF
--- a/src/main/java/org/dongguk/jjoin/domain/Recruited_period.java
+++ b/src/main/java/org/dongguk/jjoin/domain/Recruited_period.java
@@ -54,7 +54,7 @@ public class Recruited_period {
 
     public void checkFinished() {
         long now = Timestamp.valueOf(LocalDateTime.now()).getTime();
-        if (now > this.endDate.getTime() && now < this.startDate.getTime()) {
+        if (now > this.endDate.getTime() || now < this.startDate.getTime()) {
             this.isFinished = Boolean.TRUE;
         } else {
             this.isFinished = Boolean.FALSE;


### PR DESCRIPTION
모집 기간에서 OR로 표현되어야 할 식이 AND도 표현되어 있어서 수정했습니다.

- startDate와 endDate 비교에서 현재 날짜가 endDate보다 이후거나 startDate보다 이전이라면 모집 종료로 수정

**관련 이슈** 
[FIX] 모집 기간 오류 수정 https://github.com/In-lyeog-sa-mu-so/jjoin-server/issues/107

**고려해봐야할 부분**